### PR TITLE
Add automated STOP logic

### DIFF
--- a/sql/20200930-2.sql
+++ b/sql/20200930-2.sql
@@ -1,0 +1,27 @@
+-- Remove "originating" from some column names.
+-- These columns identify the voter's Slack channel and thread,
+-- which in the case of a voter status button press, is necessarily
+-- the same as the originating Slack channel and thread.
+-- Now that the change of a voter status can be automated, these
+-- columns are useful to help identify the voter, even if the "origin"
+-- of the update isn't the channel/thread themselves.
+-- Leaving " originating" for originating_slack_user_name and
+-- originating_slack_user_id.
+
+ALTER TABLE voter_status_updates
+RENAME COLUMN originating_slack_channel_name TO slack_channel_name;
+
+ALTER TABLE voter_status_updates
+RENAME COLUMN originating_slack_channel_id TO slack_channel_id;
+
+ALTER TABLE voter_status_updates
+RENAME COLUMN originating_slack_parent_message_ts TO slack_parent_message_ts;
+
+ALTER TABLE volunteer_voter_claims
+RENAME COLUMN originating_slack_channel_name TO slack_channel_name;
+
+ALTER TABLE volunteer_voter_claims
+RENAME COLUMN originating_slack_channel_id TO slack_channel_id;
+
+ALTER TABLE volunteer_voter_claims
+RENAME COLUMN originating_slack_parent_message_ts TO slack_parent_message_ts;

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,7 +21,6 @@ import redisClient from './redis_client';
 import { EntryPoint, Request, UserInfo } from './types';
 
 const app = express();
-// const MessagingResponse = twilio.twiml.MessagingResponse;
 
 const rawBodySaver = (
   req: Request,

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import Hashes from 'jshashes';
 import bodyParser from 'body-parser';
-import twilio from 'twilio';
+// import twilio from 'twilio';
 import * as Sentry from '@sentry/node';
 import morgan from 'morgan';
 import axios, { AxiosResponse } from 'axios';
@@ -21,7 +21,7 @@ import redisClient from './redis_client';
 import { EntryPoint, Request, UserInfo } from './types';
 
 const app = express();
-const MessagingResponse = twilio.twiml.MessagingResponse;
+// const MessagingResponse = twilio.twiml.MessagingResponse;
 
 const rawBodySaver = (
   req: Request,
@@ -115,6 +115,7 @@ app.post(
       await TwilioApiUtil.sendMessage(
         MESSAGE,
         { twilioPhoneNumber: TWILIO_PHONE_NUMBER, userPhoneNumber },
+        false /* outboundTextsBlocked */,
         dbMessageEntry
       );
 
@@ -133,15 +134,15 @@ const handleIncomingTwilioMessage = async (
 
   const userPhoneNumber = req.body.From;
 
-  const isBlocked = await RedisApiUtil.getHashField(
+  const inboundTextsBlocked = await RedisApiUtil.getHashField(
     redisClient,
     'twilioBlockedUserPhoneNumbers',
     userPhoneNumber
   );
 
-  if (isBlocked === '1') {
+  if (inboundTextsBlocked === '1') {
     logger.info(
-      `SERVER POST /twilio-push: Received text from blocked phone number: ${userPhoneNumber}.`
+      `SERVER.handleIncomingTwilioMessage: Received text from blocked phone number: ${userPhoneNumber}.`
     );
     return;
   }
@@ -185,6 +186,58 @@ const handleIncomingTwilioMessage = async (
     logger.info(
       `SERVER.handleIncomingTwilioMessage (${userId}): Voter is known to us (Redis returned userInfo for redisHashKey ${redisHashKey})`
     );
+
+    // Outbound texts should be blocked if either:
+    // 1. this current message is STOP, or
+    // 2. a prior interaction set outbound texts to be blocked for this user.
+    let outboundTextsBlocked = await RedisApiUtil.getHashField(
+      redisClient,
+      'slackBlockedUserPhoneNumbers',
+      userPhoneNumber
+    );
+
+    if (userMessage.toLowerCase().trim() === 'stop') {
+      logger.info(
+        `SERVER.handleIncomingTwilioMessage: Received STOP text from phone number: ${userPhoneNumber}.`
+      );
+      const messageBlocks = await SlackApiUtil.fetchSlackMessageBlocks(
+        userInfo.activeChannelId,
+        userInfo[userInfo.activeChannelId]
+      );
+
+      if (!messageBlocks) {
+        throw new Error(`Could not get Slack blocks for known user ${userId}`);
+      }
+
+      const payload = {
+        automatedButtonSelection: true,
+        message: {
+          blocks: messageBlocks,
+        },
+        container: {
+          thread_ts: userInfo[userInfo.activeChannelId],
+        },
+        channel: {
+          id: userInfo.activeChannelId,
+        },
+        user: {
+          id: null,
+        },
+      };
+
+      await SlackInteractionHandler.handleVoterStatusUpdate({
+        payload,
+        selectedVoterStatus: 'REFUSED',
+        originatingSlackUserName: 'AUTOMATED',
+        slackChannelName: userInfo.activeChannelName,
+        userPhoneNumber,
+        twilioPhoneNumber,
+        redisClient,
+      });
+      outboundTextsBlocked = true;
+      // Don't return, so the message is relayed to Slack and written into Postgres.
+    }
+
     // PUSH
     if (entryPoint === LoadBalancer.PUSH_ENTRY_POINT) {
       logger.info(
@@ -195,7 +248,8 @@ const handleIncomingTwilioMessage = async (
         { userInfo, userPhoneNumber, userMessage },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        outboundTextsBlocked
       );
       // PULL
     } else if (userInfo.confirmedDisclaimer) {
@@ -217,7 +271,8 @@ const handleIncomingTwilioMessage = async (
           { userInfo, userPhoneNumber, userMessage },
           redisClient,
           twilioPhoneNumber,
-          inboundDbMessageEntry
+          inboundDbMessageEntry,
+          outboundTextsBlocked
         );
         // Voter has no state determined
       } else {
@@ -228,7 +283,8 @@ const handleIncomingTwilioMessage = async (
           { userInfo, userPhoneNumber, userMessage },
           redisClient,
           twilioPhoneNumber,
-          inboundDbMessageEntry
+          inboundDbMessageEntry,
+          outboundTextsBlocked
         );
       }
     } else {
@@ -242,14 +298,34 @@ const handleIncomingTwilioMessage = async (
         { userInfo, userPhoneNumber, userMessage },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        outboundTextsBlocked
       );
     }
-    // Haven't seen this voter before
+    // No Slack thread for this voter's conversation with this phone number.
   } else {
     logger.info(
       `SERVER.handleIncomingTwilioMessage (${userId}): Voter is new to us (Redis returned no userInfo for redisHashKey ${redisHashKey})`
     );
+
+    if (userMessage.toLowerCase().trim() === 'stop') {
+      logger.info(
+        `SERVER.handleIncomingTwilioMessage: Received STOP text from phone number: ${userPhoneNumber}.`
+      );
+      // Block volunteers or automated system from sending messages to this number in the future,
+      // even though there is no thread from which volunteers could do so.
+      await RedisApiUtil.setHash(redisClient, 'slackBlockedUserPhoneNumbers', {
+        [userPhoneNumber]: '1',
+      });
+      // If the voter's first messsage to us is STOP, ignore any and all subsequent messages.
+      await RedisApiUtil.setHash(redisClient, 'twilioBlockedUserPhoneNumbers', {
+        [userPhoneNumber]: '1',
+      });
+      // Return so that there is no logging in PG, no Slack thread is created, and
+      // no automated response is sent to the voter.
+      return;
+    }
+
     await Router.handleNewVoter(
       { userPhoneNumber, userMessage, userId },
       redisClient,
@@ -270,19 +346,21 @@ app.post(
       '******************************************************************************************************'
     );
     logger.info('Entering SERVER POST /twilio-push');
-    const twiml = new MessagingResponse();
+    // const twiml = new MessagingResponse();
 
     if (TwilioUtil.passesAuth(req)) {
-      logger.info('SERVER.handleIncomingTwilioMessage: Passes Twilio auth.');
+      logger.info('SERVER POST /twilio-push: Passes Twilio auth.');
       await handleIncomingTwilioMessage(req, LoadBalancer.PUSH_ENTRY_POINT);
       res.writeHead(200, { 'Content-Type': 'text/xml' });
-      res.end(twiml.toString());
+      res.send();
+      // res.end(twiml.toString());
     } else {
       logger.error(
-        'SERVER.handleIncomingTwilioMessage: ERROR authenticating /twilio-push request is from Twilio.'
+        'SERVER POST /twilio-push: ERROR authenticating /twilio-push request is from Twilio.'
       );
       res.writeHead(401, { 'Content-Type': 'text/xml' });
-      res.end(twiml.toString());
+      res.send();
+      // res.end(twiml.toString());
     }
   })
 );
@@ -297,19 +375,21 @@ app.post(
       '******************************************************************************************************'
     );
     logger.info('Entering SERVER POST /twilio-pull');
-    const twiml = new MessagingResponse();
+    // const twiml = new MessagingResponse();
 
     if (TwilioUtil.passesAuth(req)) {
-      logger.info('SERVER.handleIncomingTwilioMessage: Passes Twilio auth.');
+      logger.info('SERVER POST /twilio-pull: Passes Twilio auth.');
       await handleIncomingTwilioMessage(req, LoadBalancer.PULL_ENTRY_POINT);
       res.writeHead(200, { 'Content-Type': 'text/xml' });
-      res.end(twiml.toString());
+      res.send();
+      // res.end(twiml.toString());
     } else {
       logger.error(
-        'SERVER.handleIncomingTwilioMessage: ERROR authenticating /twilio-pull request is from Twilio.'
+        'SERVER POST /twilio-pull: ERROR authenticating /twilio-pull request is from Twilio.'
       );
       res.writeHead(401, { 'Content-Type': 'text/xml' });
-      res.end(twiml.toString());
+      res.send();
+      // res.end(twiml.toString());
     }
   })
 );
@@ -381,12 +461,12 @@ app.post(
           'SERVER POST /slack: Server received non-bot Slack message INSIDE a voter thread.'
         );
 
-        const isBlocked = await RedisApiUtil.getHashField(
+        const outboundTextsBlocked = await RedisApiUtil.getHashField(
           redisClient,
           'slackBlockedUserPhoneNumbers',
           redisData.userPhoneNumber
         );
-        if (isBlocked != '1') {
+        if (outboundTextsBlocked != '1') {
           const originatingSlackUserName = await SlackApiUtil.fetchSlackUserName(
             reqBody.event.user
           );
@@ -507,7 +587,7 @@ app.post(
     );
     if (!originatingSlackChannelName) {
       throw new Error(
-        `Could not get slack channel name for slack channel ${payload.channel.id}`
+        `Could not get slack channel name for Slack channel ${payload.channel.id}`
       );
     }
 
@@ -525,7 +605,7 @@ app.post(
         payload,
         selectedVoterStatus,
         originatingSlackUserName,
-        originatingSlackChannelName,
+        slackChannelName: originatingSlackChannelName,
         userPhoneNumber: redisData.userPhoneNumber,
         twilioPhoneNumber: redisData.twilioPhoneNumber,
         redisClient,
@@ -537,7 +617,7 @@ app.post(
       await SlackInteractionHandler.handleVolunteerUpdate({
         payload,
         originatingSlackUserName,
-        originatingSlackChannelName,
+        slackChannelName: originatingSlackChannelName,
         userPhoneNumber: redisData.userPhoneNumber,
         twilioPhoneNumber: redisData.twilioPhoneNumber,
       });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import Hashes from 'jshashes';
 import bodyParser from 'body-parser';
-// import twilio from 'twilio';
 import * as Sentry from '@sentry/node';
 import morgan from 'morgan';
 import axios, { AxiosResponse } from 'axios';

--- a/src/app.ts
+++ b/src/app.ts
@@ -344,21 +344,18 @@ app.post(
       '******************************************************************************************************'
     );
     logger.info('Entering SERVER POST /twilio-push');
-    // const twiml = new MessagingResponse();
 
     if (TwilioUtil.passesAuth(req)) {
       logger.info('SERVER POST /twilio-push: Passes Twilio auth.');
       await handleIncomingTwilioMessage(req, LoadBalancer.PUSH_ENTRY_POINT);
       res.writeHead(200, { 'Content-Type': 'text/xml' });
       res.send();
-      // res.end(twiml.toString());
     } else {
       logger.error(
         'SERVER POST /twilio-push: ERROR authenticating /twilio-push request is from Twilio.'
       );
       res.writeHead(401, { 'Content-Type': 'text/xml' });
       res.send();
-      // res.end(twiml.toString());
     }
   })
 );
@@ -373,21 +370,18 @@ app.post(
       '******************************************************************************************************'
     );
     logger.info('Entering SERVER POST /twilio-pull');
-    // const twiml = new MessagingResponse();
 
     if (TwilioUtil.passesAuth(req)) {
       logger.info('SERVER POST /twilio-pull: Passes Twilio auth.');
       await handleIncomingTwilioMessage(req, LoadBalancer.PULL_ENTRY_POINT);
       res.writeHead(200, { 'Content-Type': 'text/xml' });
       res.send();
-      // res.end(twiml.toString());
     } else {
       logger.error(
         'SERVER POST /twilio-pull: ERROR authenticating /twilio-pull request is from Twilio.'
       );
       res.writeHead(401, { 'Content-Type': 'text/xml' });
       res.send();
-      // res.end(twiml.toString());
     }
   })
 );

--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -46,9 +46,9 @@ export type DatabaseVoterStatusEntry = {
   voterStatus: string | null;
   originatingSlackUserName: string | null;
   originatingSlackUserId: string | null;
-  originatingSlackChannelName: string | null;
-  originatingSlackChannelId: string | null;
-  originatingSlackParentMessageTs: number | null;
+  slackChannelName: string | null;
+  slackChannelId: string | null;
+  slackParentMessageTs: number | null;
   actionTs?: number | null;
   twilioPhoneNumber: string | null;
   isDemo: boolean | null;
@@ -63,9 +63,9 @@ export type DatabaseVolunteerVoterClaim = {
   volunteerSlackUserId: string | null;
   originatingSlackUserName: string | null;
   originatingSlackUserId: string | null;
-  originatingSlackChannelName: string | null;
-  originatingSlackChannelId: string | null;
-  originatingSlackParentMessageTs: number | null;
+  slackChannelName: string | null;
+  slackChannelId: string | null;
+  slackParentMessageTs: number | null;
   actionTs: number | null;
 };
 
@@ -409,16 +409,16 @@ export async function logVoterStatusToDb(
   const client = await pool.connect();
   try {
     await client.query(
-      'INSERT INTO voter_status_updates (user_id, user_phone_number, voter_status, originating_slack_user_name, originating_slack_user_id, originating_slack_channel_name, originating_slack_channel_id, originating_slack_parent_message_ts, action_ts, twilio_phone_number, is_demo) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);',
+      'INSERT INTO voter_status_updates (user_id, user_phone_number, voter_status, originating_slack_user_name, originating_slack_user_id, slack_channel_name, slack_channel_id, slack_parent_message_ts, action_ts, twilio_phone_number, is_demo) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);',
       [
         databaseVoterStatusEntry.userId,
         databaseVoterStatusEntry.userPhoneNumber,
         databaseVoterStatusEntry.voterStatus,
         databaseVoterStatusEntry.originatingSlackUserName,
         databaseVoterStatusEntry.originatingSlackUserId,
-        databaseVoterStatusEntry.originatingSlackChannelName,
-        databaseVoterStatusEntry.originatingSlackChannelId,
-        databaseVoterStatusEntry.originatingSlackParentMessageTs,
+        databaseVoterStatusEntry.slackChannelName,
+        databaseVoterStatusEntry.slackChannelId,
+        databaseVoterStatusEntry.slackParentMessageTs,
         databaseVoterStatusEntry.actionTs,
         databaseVoterStatusEntry.twilioPhoneNumber,
         databaseVoterStatusEntry.isDemo,
@@ -477,7 +477,7 @@ export async function logVolunteerVoterClaimToDb(
 
   try {
     await client.query(
-      'INSERT INTO volunteer_voter_claims (user_id, user_phone_number, twilio_phone_number, is_demo, volunteer_slack_user_name, volunteer_slack_user_id, originating_slack_user_name, originating_slack_user_id, originating_slack_channel_name, originating_slack_channel_id, originating_slack_parent_message_ts, action_ts) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);',
+      'INSERT INTO volunteer_voter_claims (user_id, user_phone_number, twilio_phone_number, is_demo, volunteer_slack_user_name, volunteer_slack_user_id, originating_slack_user_name, originating_slack_user_id, slack_channel_name, slack_channel_id, slack_parent_message_ts, action_ts) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);',
       [
         databaseVolunteerVoterClaimEntry.userId,
         databaseVolunteerVoterClaimEntry.userPhoneNumber,
@@ -487,9 +487,9 @@ export async function logVolunteerVoterClaimToDb(
         databaseVolunteerVoterClaimEntry.volunteerSlackUserId,
         databaseVolunteerVoterClaimEntry.originatingSlackUserName,
         databaseVolunteerVoterClaimEntry.originatingSlackUserId,
-        databaseVolunteerVoterClaimEntry.originatingSlackChannelName,
-        databaseVolunteerVoterClaimEntry.originatingSlackChannelId,
-        databaseVolunteerVoterClaimEntry.originatingSlackParentMessageTs,
+        databaseVolunteerVoterClaimEntry.slackChannelName,
+        databaseVolunteerVoterClaimEntry.slackChannelId,
+        databaseVolunteerVoterClaimEntry.slackParentMessageTs,
         databaseVolunteerVoterClaimEntry.actionTs,
       ]
     );

--- a/src/router.test.js
+++ b/src/router.test.js
@@ -243,8 +243,12 @@ describe('handleNewVoter', () => {
     );
   });
 
+  test('Passes outboundTextsBlocked=false to TwilioApiUtil if voter is not blocked', () => {
+    expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toBe(false);
+  });
+
   test('Creates outbound database entry and passes to TwilioApiUtil for logging', () => {
-    expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toEqual(
+    expect(TwilioApiUtil.sendMessage.mock.calls[0][3]).toEqual(
       expect.objectContaining({
         direction: 'OUTBOUND',
         automated: true,
@@ -254,7 +258,7 @@ describe('handleNewVoter', () => {
 
   test('Includes updated lastVoterMessageSecsFromEpoch in outbound database entry object for logging', () => {
     const secsFromEpochNow = Math.round(Date.now() / 1000);
-    const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][2];
+    const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][3];
     const newLastVoterMessageSecsFromEpoch =
       dbMessageEntry.lastVoterMessageSecsFromEpoch;
     expect(newLastVoterMessageSecsFromEpoch - secsFromEpochNow).toBeLessThan(
@@ -429,7 +433,8 @@ const determineVoterStateWrapper = (
   userOptions,
   redisClient,
   twilioPhoneNumber,
-  inboundDbMessageEntry
+  inboundDbMessageEntry,
+  outboundTextsBlocked
 ) => {
   return new Promise((resolve) => {
     resolve(
@@ -437,7 +442,8 @@ const determineVoterStateWrapper = (
         userOptions,
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        outboundTextsBlocked
       )
     );
   });
@@ -475,7 +481,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         '+12054985052',
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       );
     });
     test('Passes voter message to Slack', () => {
@@ -550,7 +557,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         '+12054985052',
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       );
     });
 
@@ -566,8 +574,12 @@ describe('determineVoterState', () => {
       );
     });
 
+    test('Passes outboundTextsBlocked=false to TwilioApiUtil if voter is not blocked', () => {
+      expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toBe(false);
+    });
+
     test('Creates outbound database entry and passes to TwilioApiUtil for logging', () => {
-      expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toEqual(
+      expect(TwilioApiUtil.sendMessage.mock.calls[0][3]).toEqual(
         expect.objectContaining({
           direction: 'OUTBOUND',
           automated: true,
@@ -577,7 +589,7 @@ describe('determineVoterState', () => {
 
     test('Includes updated lastVoterMessageSecsFromEpoch in outbound database entry object for logging', () => {
       const secsFromEpochNow = Math.round(Date.now() / 1000);
-      const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][2];
+      const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][3];
       const newLastVoterMessageSecsFromEpoch =
         dbMessageEntry.lastVoterMessageSecsFromEpoch;
       expect(newLastVoterMessageSecsFromEpoch - secsFromEpochNow).toBeLessThan(
@@ -727,7 +739,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expect(TwilioApiUtil.sendMessage.mock.calls[0][0]).toEqual(
           expect.stringMatching(
@@ -743,6 +756,22 @@ describe('determineVoterState', () => {
       });
     });
 
+    test('Passes outboundTextsBlocked=false to TwilioApiUtil if voter is not blocked', () => {
+      return determineVoterStateWrapper(
+        {
+          userPhoneNumber: '+1234567890',
+          userMessage: 'NC',
+          userInfo,
+        },
+        redisClient,
+        twilioPhoneNumber,
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
+      ).then(() => {
+        expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toBe(false);
+      });
+    });
+
     test('Creates outbound database entry and passes to TwilioApiUtil for logging', () => {
       return determineVoterStateWrapper(
         {
@@ -752,9 +781,10 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
-        expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toEqual(
+        expect(TwilioApiUtil.sendMessage.mock.calls[0][3]).toEqual(
           expect.objectContaining({
             direction: 'OUTBOUND',
             automated: true,
@@ -772,10 +802,11 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         const secsFromEpochNow = Math.round(Date.now() / 1000);
-        const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][2];
+        const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][3];
         const newLastVoterMessageSecsFromEpoch =
           dbMessageEntry.lastVoterMessageSecsFromEpoch;
         expect(
@@ -793,7 +824,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expectNthSlackMessageToChannel(
           'CTHELOBBYID',
@@ -813,7 +845,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expectNthSlackMessageToChannel(
           'CTHELOBBYID',
@@ -833,7 +866,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expectNthSlackMessageToChannel(
           'CTHELOBBYID',
@@ -853,7 +887,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         const MD5 = new Hashes.MD5();
         const userId = MD5.hex('+1234567890').substring(0, 5);
@@ -877,7 +912,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expectNthSlackMessageToChannel('north-carolina-3', 0, [
           'New North Carolina voter',
@@ -900,7 +936,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expectNthSlackMessageToChannel('north-carolina-5', 0, [
           'New North Carolina voter',
@@ -923,7 +960,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expectNthSlackMessageToChannel('north-carolina-3', 0, [
           'New North Carolina voter',
@@ -946,7 +984,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expectNthSlackMessageToChannel('north-carolina-10', 0, [
           'New North Carolina voter',
@@ -1001,7 +1040,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         // 53rd demo NC voter goes to #demo-north-carolina-2
         expectNthSlackMessageToChannel('demo-north-carolina-2', 0, [
@@ -1019,7 +1059,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         // # of assertions = # of message parts + # of calls with parentMessageTs
         expect.assertions(1);
@@ -1043,7 +1084,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expect.assertions(2);
         const secsFromEpochNow = Math.round(Date.now() / 1000);
@@ -1084,7 +1126,8 @@ describe('determineVoterState', () => {
         },
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       ).then(() => {
         expect.assertions(1);
         for (call of RedisApiUtil.setHash.mock.calls) {
@@ -1116,7 +1159,8 @@ const handleDisclaimerWrapper = (
         userOptions,
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       )
     );
   });
@@ -1232,8 +1276,12 @@ describe('handleDisclaimer', () => {
       );
     });
 
+    test('Passes outboundTextsBlocked=false to TwilioApiUtil if voter is not blocked', () => {
+      expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toBe(false);
+    });
+
     test('Creates outbound database entry and passes to TwilioApiUtil for logging', () => {
-      expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toEqual(
+      expect(TwilioApiUtil.sendMessage.mock.calls[0][3]).toEqual(
         expect.objectContaining({
           direction: 'OUTBOUND',
           automated: true,
@@ -1243,7 +1291,7 @@ describe('handleDisclaimer', () => {
 
     test('Includes updated lastVoterMessageSecsFromEpoch in outbound database entry object for logging', () => {
       const secsFromEpochNow = Math.round(Date.now() / 1000);
-      const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][2];
+      const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][3];
       const newLastVoterMessageSecsFromEpoch =
         dbMessageEntry.lastVoterMessageSecsFromEpoch;
       expect(newLastVoterMessageSecsFromEpoch - secsFromEpochNow).toBeLessThan(
@@ -1356,8 +1404,12 @@ describe('handleDisclaimer', () => {
       );
     });
 
+    test('Passes outboundTextsBlocked=false to TwilioApiUtil if voter is not blocked', () => {
+      expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toBe(false);
+    });
+
     test('Creates outbound database entry and passes to TwilioApiUtil for logging', () => {
-      expect(TwilioApiUtil.sendMessage.mock.calls[0][2]).toEqual(
+      expect(TwilioApiUtil.sendMessage.mock.calls[0][3]).toEqual(
         expect.objectContaining({
           direction: 'OUTBOUND',
           automated: true,
@@ -1367,7 +1419,7 @@ describe('handleDisclaimer', () => {
 
     test('Includes updated lastVoterMessageSecsFromEpoch in outbound database entry object for logging', () => {
       const secsFromEpochNow = Math.round(Date.now() / 1000);
-      const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][2];
+      const dbMessageEntry = TwilioApiUtil.sendMessage.mock.calls[0][3];
       const newLastVoterMessageSecsFromEpoch =
         dbMessageEntry.lastVoterMessageSecsFromEpoch;
       expect(newLastVoterMessageSecsFromEpoch - secsFromEpochNow).toBeLessThan(
@@ -1452,7 +1504,8 @@ const handleClearedVoterWrapper = (
         userOptions,
         redisClient,
         twilioPhoneNumber,
-        inboundDbMessageEntry
+        inboundDbMessageEntry,
+        false /* outboundTextsBlocked */
       )
     );
   });

--- a/src/twilio_api_util.ts
+++ b/src/twilio_api_util.ts
@@ -14,9 +14,18 @@ export async function sendMessage(
     twilioPhoneNumber: string;
     userPhoneNumber: string;
   },
+  outboundTextsBlocked: boolean,
   databaseMessageEntry?: DbApiUtil.DatabaseMessageEntry
 ): Promise<void> {
   logger.info(`ENTERING TWILIOAPIUTIL.sendMessage`);
+
+  if (outboundTextsBlocked) {
+    logger.info(
+      `SLACKAPIUTIL.sendMessage: Message ${message} will not be sent because texts to user ${options.userPhoneNumber} are blocked.`
+    );
+    return;
+  }
+
   if (databaseMessageEntry) {
     logger.info(
       `TWILIOAPIUTIL.sendMessage: This Twilio message send will log to DB (databaseMessageEntry is not null).`


### PR DESCRIPTION
In addition to the existing ability for volunteers to manually set a voter to REFUSE so that no texts are sent to them, this PR adds the following automated logic:

1. Initial messages that match STOP are not replied to with an automated welcome or received by Slack
2. Subsequent messages from a voter who initiated conversation with STOP are not replied to or received by Slack. This cannot be undone other than by manually accessing Redis. With no thread in Slack, there is no way for volunteers to send messages to these voters.
3. Any non-initial STOP messages sent from a voter will automatically update the voter's status to REFUSED, both in Postgres and in Slack, and subsequent automated or volunteer messages to them will be blocked unless this action is undone. This STOP message is relayed to Slack so that the volunteer knows what is going on, and subsequent messages are relayed to Slack as well so the volunteer has a full view of that voter's interactions and experience.
4. Adding to the existing logic associated with the manual REFUSED button available to volunteers, pressing this button disables not just volunteer messages to the voter but also automated messages (in case a voter repeatedly texts while in the lobby that they don't want a response).