### PR TITLE
`authed_users` check isn't necessary

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -537,7 +537,12 @@ app.post(
         retryCount,
         retryReason,
       });
-    } else if (reqBody.event.type === 'app_mention' && !retryReason) {
+    } else if (
+      reqBody.event.type === 'app_mention' &&
+      // Require that the Slack bot be the (first) user mentioned.
+      reqBody.event.text.startsWith(`<@${process.env.SLACK_BOT_USER_ID}>`) &&
+      !retryReason
+    ) {
       await enqueueBackgroundTask('slackAppMentionEventHandler', reqBody);
     }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -537,12 +537,7 @@ app.post(
         retryCount,
         retryReason,
       });
-    } else if (
-      reqBody.event.type === 'app_mention' &&
-      // Require that the Slack bot be the (first) user mentioned.
-      reqBody.authed_users[0] === process.env.SLACK_BOT_USER_ID &&
-      !retryReason
-    ) {
+    } else if (reqBody.event.type === 'app_mention' && !retryReason) {
       await enqueueBackgroundTask('slackAppMentionEventHandler', reqBody);
     }
 


### PR DESCRIPTION
Small fix here. This `authed_users` check doesn't do what the comment suggests it does. `authed_users` is a list of (probably human) users who have installed the app, not a list of the actual user IDs mentioned. So for me at least, this condition was always returning false.

In any event, the `slackAppMentionEventHandler` also checks the Slack bot is the first user mentioned, so this doesn't do anything other than possibly saving a few background tasks from being enqueued.