### PR TITLE
Add Twilio message callbacks

### DIFF
--- a/sql/20201004.sql
+++ b/sql/20201004.sql
@@ -26,6 +26,18 @@ ADD COLUMN twilio_callback_timestamp timestamptz;
 ALTER TABLE messages
 ALTER COLUMN slack_parent_message_ts TYPE text USING trim(to_char(slack_parent_message_ts, '99999999999999999999999999.999999'));
 
-
 ALTER TABLE messages
 ALTER COLUMN slack_message_ts TYPE text USING trim(to_char(slack_message_ts, '99999999999999999999999999.999999'));
+
+ALTER TABLE voter_status_updates
+ALTER COLUMN slack_parent_message_ts TYPE text USING trim(to_char(slack_parent_message_ts, '99999999999999999999999999.999999'));
+
+ALTER TABLE voter_status_updates
+ALTER COLUMN action_ts TYPE text USING trim(to_char(action_ts, '99999999999999999999999999.999999'));
+
+ALTER TABLE volunteer_voter_claims
+ALTER COLUMN slack_parent_message_ts TYPE text USING trim(to_char(slack_parent_message_ts, '99999999999999999999999999.999999'));
+
+ALTER TABLE volunteer_voter_claims
+ALTER COLUMN action_ts TYPE text USING trim(to_char(action_ts, '99999999999999999999999999.999999'));
+

--- a/sql/20201004.sql
+++ b/sql/20201004.sql
@@ -1,0 +1,31 @@
+-- couple more indexes for message
+
+CREATE INDEX idx_messages_slack_parent_message_ts
+ON messages(slack_parent_message_ts);
+
+CREATE INDEX idx_messages_twilio_message_sid
+ON messages(twilio_message_sid);
+
+-- add fields to messages to store Twilio callback data
+
+ALTER TABLE messages
+ADD COLUMN twilio_callback_status text;
+
+
+ALTER TABLE messages
+ADD COLUMN twilio_callback_timestamp timestamptz;
+
+-- store slack message timestamps as text, not numbers (they're not really numbers)
+-- See: https://github.com/slackhq/slack-api-docs/issues/7#issuecomment-67913241
+--
+-- When converting, we need to be careful to format the existing timestamps
+-- with 6 decimal places. This is because in the past we were storing a ts
+-- provided by slack as a number, so "1234.567000" was being stored as 1234.567.
+-- In order to now convert it back to the original timestamp, we need to use
+-- 6 decimal places to that it ends up as "1234.567000" and not "1234.567".
+ALTER TABLE messages
+ALTER COLUMN slack_parent_message_ts TYPE text USING trim(to_char(slack_parent_message_ts, '99999999999999999999999999.999999'));
+
+
+ALTER TABLE messages
+ALTER COLUMN slack_message_ts TYPE text USING trim(to_char(slack_message_ts, '99999999999999999999999999.999999'));

--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -75,6 +75,7 @@ async function slackInteractivityHandler(payload: SlackEventPayload) {
 
 async function slackMessageEventHandler(
   reqBody: SlackEventRequestBody,
+  twilioCallbackURL: string,
   {
     retryCount,
     retryReason,
@@ -119,6 +120,7 @@ async function slackMessageEventHandler(
         redisClient,
         redisData,
         originatingSlackUserName,
+        twilioCallbackURL,
         { retryCount, retryReason }
       );
     } else {

--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -49,7 +49,7 @@ export type DatabaseVoterStatusEntry = {
   slackChannelName: string | null;
   slackChannelId: string | null;
   slackParentMessageTs: string | null;
-  actionTs?: number | null;
+  actionTs?: string | null;
   twilioPhoneNumber: string | null;
   isDemo: boolean | null;
 };
@@ -66,7 +66,7 @@ export type DatabaseVolunteerVoterClaim = {
   slackChannelName: string | null;
   slackChannelId: string | null;
   slackParentMessageTs: string | null;
-  actionTs: number | null;
+  actionTs: string | null;
 };
 
 export async function logMessageToDb(
@@ -534,16 +534,14 @@ export async function logTwilioStatusToDb(
 
     if (result.rows.length > 0) {
       const row = result.rows[0];
-      console.log({
-        slackChannel: row.slack_channel,
-        slackMessageTs: row.slack_message_ts,
-      });
       return {
         slackChannel: row.slack_channel,
         slackMessageTs: row.slack_message_ts,
       };
     } else {
-      logger.error(`DBAPIUTIL.getLatestVoterStatus: No voter status for user`);
+      logger.error(
+        `DBAPIUTIL.logTwilioStatusToDb: No message with sid ${messageSid}`
+      );
       return null;
     }
   } finally {

--- a/src/router.ts
+++ b/src/router.ts
@@ -26,7 +26,7 @@ type UserOptions = {
 };
 
 type AdminCommandParams = {
-  commandParentMessageTs: number;
+  commandParentMessageTs: string;
   routingSlackUserName: string;
   previousSlackChannelName: string;
 };
@@ -76,7 +76,8 @@ export async function welcomePotentialVoter(
   redisClient: PromisifiedRedisClient,
   twilioPhoneNumber: string,
   inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry,
-  entryPoint: EntryPoint
+  entryPoint: EntryPoint,
+  twilioCallbackURL: string
 ): Promise<void> {
   logger.debug('ENTERING ROUTER.welcomePotentialVoter');
   const userInfo = prepareUserInfoForNewVoter({
@@ -87,7 +88,11 @@ export async function welcomePotentialVoter(
 
   await TwilioApiUtil.sendMessage(
     MessageConstants.WELCOME_VOTER(),
-    { userPhoneNumber: userOptions.userPhoneNumber, twilioPhoneNumber },
+    {
+      userPhoneNumber: userOptions.userPhoneNumber,
+      twilioPhoneNumber,
+      twilioCallbackURL,
+    },
     DbApiUtil.populateAutomatedDbMessageEntry(userInfo)
   );
 
@@ -123,7 +128,8 @@ const introduceNewVoterToSlackChannel = async (
   twilioPhoneNumber: string,
   inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry,
   entryPoint: EntryPoint,
-  slackChannelName: string
+  slackChannelName: string,
+  twilioCallbackURL: string
 ) => {
   logger.debug('ENTERING ROUTER.introduceNewVoterToSlackChannel');
   logger.debug(
@@ -143,7 +149,11 @@ const introduceNewVoterToSlackChannel = async (
     // Welcome the voter
     await TwilioApiUtil.sendMessage(
       messageToVoter,
-      { userPhoneNumber: userInfo.userPhoneNumber, twilioPhoneNumber },
+      {
+        userPhoneNumber: userInfo.userPhoneNumber,
+        twilioPhoneNumber,
+        twilioCallbackURL,
+      },
       DbApiUtil.populateAutomatedDbMessageEntry(userInfo)
     );
   }
@@ -270,7 +280,8 @@ export async function handleNewVoter(
   redisClient: PromisifiedRedisClient,
   twilioPhoneNumber: string,
   inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry,
-  entryPoint: EntryPoint
+  entryPoint: EntryPoint,
+  twilioCallbackURL: string
 ): Promise<void> {
   logger.debug('ENTERING ROUTER.handleNewVoter');
   const userMessage = userOptions.userMessage;
@@ -330,7 +341,8 @@ export async function handleNewVoter(
     twilioPhoneNumber,
     inboundDbMessageEntry,
     entryPoint,
-    slackChannelName
+    slackChannelName,
+    twilioCallbackURL
   );
 }
 
@@ -342,7 +354,7 @@ const postUserMessageHistoryToSlack = async (
     destinationSlackParentMessageTs,
     destinationSlackChannelId,
   }: {
-    destinationSlackParentMessageTs: number;
+    destinationSlackParentMessageTs: string;
     destinationSlackChannelId: string;
   }
 ) => {
@@ -390,7 +402,7 @@ const routeVoterToSlackChannelHelper = async (
   }: {
     destinationSlackChannelName: string;
     destinationSlackChannelId: string;
-    destinationSlackParentMessageTs: number;
+    destinationSlackParentMessageTs: string;
   },
   timestampOfLastMessageInThread?: string
 ) => {
@@ -704,7 +716,8 @@ export async function determineVoterState(
   userOptions: UserOptions & { userInfo: UserInfo },
   redisClient: PromisifiedRedisClient,
   twilioPhoneNumber: string,
-  inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry
+  inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry,
+  twilioCallbackURL: string
 ): Promise<void> {
   logger.debug('ENTERING ROUTER.determineVoterState');
   const userInfo = userOptions.userInfo;
@@ -745,7 +758,7 @@ export async function determineVoterState(
 
       await TwilioApiUtil.sendMessage(
         MessageConstants.CLARIFY_STATE(),
-        { userPhoneNumber, twilioPhoneNumber },
+        { userPhoneNumber, twilioPhoneNumber, twilioCallbackURL },
         DbApiUtil.populateAutomatedDbMessageEntry(userInfo)
       );
       await SlackApiUtil.sendMessage(
@@ -783,7 +796,7 @@ export async function determineVoterState(
 
   await TwilioApiUtil.sendMessage(
     messageToVoter,
-    { userPhoneNumber, twilioPhoneNumber },
+    { userPhoneNumber, twilioPhoneNumber, twilioCallbackURL },
     DbApiUtil.populateAutomatedDbMessageEntry(userInfo)
   );
   await SlackApiUtil.sendMessage(`*Automated Message:* ${messageToVoter}`, {
@@ -820,7 +833,8 @@ export async function clarifyHelplineRequest(
   userOptions: UserOptions & { userInfo: UserInfo },
   redisClient: PromisifiedRedisClient,
   twilioPhoneNumber: string,
-  inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry
+  inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry,
+  twilioCallbackURL: string
 ): Promise<void> {
   logger.debug('ENTERING ROUTER.clarifyHelplineRequest');
   const userInfo = userOptions.userInfo;
@@ -828,7 +842,11 @@ export async function clarifyHelplineRequest(
 
   await TwilioApiUtil.sendMessage(
     MessageConstants.CLARIFY_HELPLINE_REQUEST(),
-    { userPhoneNumber: userOptions.userPhoneNumber, twilioPhoneNumber },
+    {
+      userPhoneNumber: userOptions.userPhoneNumber,
+      twilioPhoneNumber,
+      twilioCallbackURL,
+    },
     DbApiUtil.populateAutomatedDbMessageEntry(userInfo)
   );
 
@@ -860,7 +878,8 @@ export async function handleDisclaimer(
   userOptions: UserOptions & { userInfo: UserInfo },
   redisClient: PromisifiedRedisClient,
   twilioPhoneNumber: string,
-  inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry
+  inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry,
+  twilioCallbackURL: string
 ): Promise<void> {
   logger.debug('ENTERING ROUTER.handleDisclaimer');
   const userInfo = userOptions.userInfo;
@@ -909,7 +928,11 @@ export async function handleDisclaimer(
   );
   await TwilioApiUtil.sendMessage(
     automatedMessage,
-    { userPhoneNumber: userOptions.userPhoneNumber, twilioPhoneNumber },
+    {
+      userPhoneNumber: userOptions.userPhoneNumber,
+      twilioPhoneNumber,
+      twilioCallbackURL,
+    },
     DbApiUtil.populateAutomatedDbMessageEntry(userInfo)
   );
   await SlackApiUtil.sendMessage(
@@ -922,7 +945,8 @@ export async function handleClearedVoter(
   userOptions: UserOptions & { userInfo: UserInfo },
   redisClient: PromisifiedRedisClient,
   twilioPhoneNumber: string,
-  inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry
+  inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry,
+  twilioCallbackURL: string
 ): Promise<void> {
   logger.debug('ENTERING ROUTER.handleClearedVoter');
   const userInfo = userOptions.userInfo;
@@ -964,6 +988,7 @@ export async function handleClearedVoter(
     await TwilioApiUtil.sendMessage(welcomeBackMessage, {
       userPhoneNumber: userOptions.userPhoneNumber,
       twilioPhoneNumber,
+      twilioCallbackURL,
     });
     await SlackApiUtil.sendMessage(
       `*Automated Message:* ${welcomeBackMessage}`,
@@ -984,6 +1009,7 @@ export async function handleSlackVoterThreadMessage(
   redisClient: PromisifiedRedisClient,
   redisData: UserInfo,
   originatingSlackUserName: string,
+  twilioCallbackURL: string,
   {
     retryCount,
     retryReason,
@@ -1000,7 +1026,9 @@ export async function handleSlackVoterThreadMessage(
     `ROUTER.handleSlackVoterThreadMessage: Successfully determined userPhoneNumber from Redis`
   );
   const unprocessedSlackMessage = reqBody.event.text;
-  logger.debug(`Received message from Slack: ${unprocessedSlackMessage}`);
+  logger.debug(
+    `Received message from Slack (channel ${reqBody.event.channel} ts ${reqBody.event.ts}): ${unprocessedSlackMessage}`
+  );
 
   // If the message doesn't need processing.
   let messageToSend = unprocessedSlackMessage;
@@ -1051,7 +1079,7 @@ export async function handleSlackVoterThreadMessage(
 
     await TwilioApiUtil.sendMessage(
       messageToSend,
-      { userPhoneNumber, twilioPhoneNumber },
+      { userPhoneNumber, twilioPhoneNumber, twilioCallbackURL },
       outboundDbMessageEntry
     );
     // Slack message is from inactive Slack thread.
@@ -1071,8 +1099,8 @@ export type SlackEventRequestBody = {
     type: string;
     hidden: boolean;
     text: string;
-    ts: number;
-    thread_ts: number;
+    ts: string;
+    thread_ts: string;
     user: string;
     channel: string;
   };
@@ -1104,7 +1132,7 @@ export async function handleSlackAdminCommand(
 
   switch (adminCommandArgs.command) {
     case CommandUtil.ROUTE_VOTER: {
-      // TODO: Move some of this logic to CommandUtil, so this swith statement
+      // TODO: Move some of this logic to CommandUtil, so this switch statement
       // is cleaner.
       const redisHashKey = `${adminCommandArgs.userId}:${adminCommandArgs.twilioPhoneNumber}`;
       logger.debug(

--- a/src/slack_api_util.ts
+++ b/src/slack_api_util.ts
@@ -311,7 +311,7 @@ export async function addSlackMessageReaction(
 
   if (!response.data.ok) {
     throw new Error(
-      `SLACKAPIUTIL.sendMessage: ERROR in sending Slack message: ${response.data.error}`
+      `SLACKAPIUTIL.addSlackMessageReaction: ERROR in adding reaction: ${response.data.error}`
     );
   }
 }

--- a/src/slack_api_util.ts
+++ b/src/slack_api_util.ts
@@ -11,13 +11,13 @@ import { PromisifiedRedisClient } from './redis_client';
 type SlackSendMessageResponse = {
   data: {
     channel: string;
-    ts: number;
+    ts: string;
   };
 };
 
 type SlackSendMessageOptions = {
   channel: string;
-  parentMessageTs?: number;
+  parentMessageTs?: string;
   blocks?: SlackBlock[];
 };
 
@@ -214,7 +214,7 @@ export async function fetchSlackUserName(
 // See reference here: https://api.slack.com/messaging/retrieving#individual_messages
 export async function fetchSlackMessageBlocks(
   channelId: string,
-  messageTs: number
+  messageTs: string
 ): Promise<SlackBlock[] | null> {
   const response = await axios.get(
     'https://slack.com/api/conversations.history',
@@ -286,6 +286,32 @@ export async function updateSlackChannelNamesAndIdsInRedis(
       redisClient,
       'slackPodChannelIds',
       slackChannelNamesAndIds
+    );
+  }
+}
+
+export async function addSlackMessageReaction(
+  messageChannel: string,
+  messageTs: string,
+  reaction: string
+): Promise<void> {
+  const response = await axios.post(
+    'https://slack.com/api/reactions.add',
+    {
+      channel: messageChannel,
+      timestamp: messageTs,
+      name: reaction,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.SLACK_BOT_ACCESS_TOKEN}`,
+      },
+    }
+  );
+
+  if (!response.data.ok) {
+    throw new Error(
+      `SLACKAPIUTIL.sendMessage: ERROR in sending Slack message: ${response.data.error}`
     );
   }
 }

--- a/src/slack_interaction_api_util.ts
+++ b/src/slack_interaction_api_util.ts
@@ -12,7 +12,7 @@ export async function replaceSlackMessageBlocks({
   newBlocks,
 }: {
   slackChannelId: string;
-  slackParentMessageTs: number;
+  slackParentMessageTs: string;
   newBlocks: SlackBlock[];
 }): Promise<void> {
   logger.info('ENTERING SLACKINTERACTIONAPIUTIL.replaceSlackMessageBlocks');
@@ -50,7 +50,7 @@ export function addBackVoterStatusPanel({
   oldBlocks,
 }: {
   slackChannelId: string;
-  slackParentMessageTs: number;
+  slackParentMessageTs: string;
   oldBlocks: SlackBlock[];
 }): Promise<void> {
   logger.info('ENTERING SLACKINTERACTIONAPIUTIL.addBackVoterStatusPanel');

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -13,7 +13,7 @@ export type VoterStatusUpdate = VoterStatus | 'UNDO';
 
 export type SlackEventPayload = {
   container: {
-    thread_ts: number;
+    thread_ts: string;
   };
   channel: {
     id: string;
@@ -30,7 +30,7 @@ export type SlackEventPayload = {
 
 export type SlackSyntheticPayload = {
   container: {
-    thread_ts: number;
+    thread_ts: string;
   };
   channel: {
     id: string;

--- a/src/twilio_api_util.ts
+++ b/src/twilio_api_util.ts
@@ -13,6 +13,7 @@ export async function sendMessage(
   options: {
     twilioPhoneNumber: string;
     userPhoneNumber: string;
+    twilioCallbackURL: string;
   },
   databaseMessageEntry?: DbApiUtil.DatabaseMessageEntry
 ): Promise<void> {
@@ -33,6 +34,7 @@ export async function sendMessage(
       body: message,
       from: options.twilioPhoneNumber,
       to: options.userPhoneNumber,
+      statusCallback: options.twilioCallbackURL,
     });
 
     logger.info(`TWILIOAPIUTIL.sendMessage: Successfully sent Twilio message,

--- a/src/twilio_status_callback_handler.ts
+++ b/src/twilio_status_callback_handler.ts
@@ -1,0 +1,51 @@
+import { logTwilioStatusToDb } from './db_api_util';
+import logger from './logger';
+import { addSlackMessageReaction } from './slack_api_util';
+import { Request } from './types';
+
+// Twilio statuses that represent the final state of a message. The value
+// in this map is the emoji reaction to add to the Slack message.
+const FINAL_STATUSES: { [status: string]: string } = {
+  delivered: 'white_check_mark',
+  undelivered: 'x',
+  failed: 'x',
+};
+
+export async function handleTwilioStatusCallback(req: Request): Promise<void> {
+  const { MessageStatus: messageStatus, MessageSid: messageSid } = req.body;
+
+  logger.info(
+    `HANDLING TWILIO CALLBACK: message sid ${messageSid} has status ${messageStatus}`
+  );
+
+  // Twilio delivers callbacks for lots of intermediate states (queued, sent
+  // to carrier, etc.). We just care about the final status of the message,
+  // so we don't update Postgres for those intermediate statuses.
+  if (!(messageStatus in FINAL_STATUSES)) {
+    logger.info(`Twilio status is non-final; not processing`);
+    return;
+  }
+
+  // Update the Postgres DB with the message status and current timestamp
+  const slackMessageInfo = await logTwilioStatusToDb(messageSid, messageStatus);
+  if (!slackMessageInfo) {
+    logger.error(
+      `TWILIO STATUS CALLBACK: No message with sid ${messageSid}; not updating slack`
+    );
+    return;
+  }
+
+  if (!slackMessageInfo.slackChannel || !slackMessageInfo.slackMessageTs) {
+    logger.info(
+      `Message SID ${messageSid} corresponds to a message without a slack message; not updating slack`
+    );
+    return;
+  }
+
+  // Update the slack message to indicate success/failure
+  await addSlackMessageReaction(
+    slackMessageInfo.slackChannel,
+    slackMessageInfo.slackMessageTs,
+    FINAL_STATUSES[messageStatus]
+  );
+}

--- a/src/twilio_util.ts
+++ b/src/twilio_util.ts
@@ -1,10 +1,14 @@
 import express from 'express';
 import twilio from 'twilio';
 
+function requestFullURL(req: express.Request) {
+  return `https://${req.headers.host}${req.url}`;
+}
+
 export function passesAuth(req: express.Request): boolean {
   const twilioSignature = req.headers['x-twilio-signature'];
   const params = req.body;
-  const url = `https://${req.headers.host}${req.url}`;
+  const url = requestFullURL(req);
 
   return twilio.validateRequest(
     process.env.TWILIO_AUTH_TOKEN!,
@@ -12,4 +16,8 @@ export function passesAuth(req: express.Request): boolean {
     url,
     params
   );
+}
+
+export function twilioCallbackURL(req: express.Request): string {
+  return `https://${req.headers.host}/twilio-callback`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ type UserInfoCore = {
 };
 
 type UserInfoChannels = {
-  [channel: string]: number; // mapping of channel ID to message timestamp
+  [channel: string]: string; // mapping of channel ID to message timestamp
 };
 
 export type UserInfo = UserInfoCore & UserInfoChannels;


### PR DESCRIPTION
This PR does a couple things:

- Specify a callback URL when sending a message to Twilio, so we get notified about delivery success/failure of our text messages
- Handle these callbacks by updating the DB and adding a reaction to the Slack message
- Store message timestamps from Slack as strings, not numbers. This is important because right now a message TS of `1234.567000` from slack gets stored as `1234.567`. But if you try to pass `1234.567` to the slack API when you're trying to do something with that message, Slack will say that's an invalid timestamp -- the timestamps are supposed to be strings with the same number of digits of precision as slack tell you, so dropping the trailing 0's makes it invalid. See this for details: https://github.com/slackhq/slack-api-docs/issues/7#issuecomment-67913241

**IMPORTANT**: this now requires the bot to have the `reactions:write` permission. I've added this to the VoteAmerica staging and prod instances, but you'll have to add it to your dev instances to test this out.
