### PR TITLE
Open Slack modal immediately and update asynchronously

### DIFF
--- a/external_config/slack.md
+++ b/external_config/slack.md
@@ -32,6 +32,8 @@
 
 #### Reset Demo
 
+This should be added as a **messages** shortcut.
+
 - **Name:** Reset Demo
 - **Short Description:** Closes this conversation, allowing the volunteer to message the demo line again as a new mock voter.
 - **Callback ID:** reset_demo

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "node -r source-map-support/register build/server.js",
     "develop": "NODE_ENV=development nodemon --watch ./src --exec 'ts-node' --files ./src/server.ts",
     "heroku-postbuild": "npm install && npm run build",
-    "test": "LOG_LEVEL=info DOTENV_CONFIG_PATH=.env.test NODE_ENV=test node -r dotenv/config ./node_modules/.bin/jest ./src",
+    "test": "LOG_LEVEL=fatal DOTENV_CONFIG_PATH=.env.test NODE_ENV=test node -r dotenv/config ./node_modules/.bin/jest ./src",
     "sls": "serverless",
     "format:check": "prettier --check --ignore-path .gitignore ./src",
     "format:write": "prettier --write --ignore-path .gitignore ./src",

--- a/src/app.ts
+++ b/src/app.ts
@@ -607,7 +607,10 @@ app.post(
 
     const metadata: InteractivityHandlerMetadata = {};
 
-    if (payload.type === 'message_action') {
+    if (
+      payload.type === 'message_action' &&
+      payload.callback_id === 'reset_demo'
+    ) {
       // For message actions, we always show a confirmation modal. Because we
       // have to show this modal within 3 seconds, we immediately make the call
       // to show a loading state, and then pass the modal ID on to the async

--- a/src/slack_api_util.ts
+++ b/src/slack_api_util.ts
@@ -8,6 +8,14 @@ import { SlackBlock, SlackView } from './slack_block_util';
 import * as RedisApiUtil from './redis_api_util';
 import { PromisifiedRedisClient } from './redis_client';
 
+const slackAPI = axios.create({
+  baseURL: 'https://slack.com/api/',
+});
+slackAPI.defaults.headers.post['Content-Type'] = 'application/json';
+slackAPI.defaults.headers.post[
+  'Authorization'
+] = `Bearer ${process.env.SLACK_BOT_ACCESS_TOKEN}`;
+
 type SlackSendMessageResponse = {
   data: {
     channel: string;
@@ -54,22 +62,13 @@ export async function sendMessage(
   }
 
   try {
-    const response = await axios.post(
-      'https://slack.com/api/chat.postMessage',
-      {
-        'Content-Type': 'application/json',
-        channel: options.channel,
-        text: message,
-        token: process.env.SLACK_BOT_ACCESS_TOKEN,
-        thread_ts: options.parentMessageTs,
-        blocks: options.blocks,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${process.env.SLACK_BOT_ACCESS_TOKEN}`,
-        },
-      }
-    );
+    const response = await slackAPI.post('chat.postMessage', {
+      channel: options.channel,
+      text: message,
+      token: process.env.SLACK_BOT_ACCESS_TOKEN,
+      thread_ts: options.parentMessageTs,
+      blocks: options.blocks,
+    });
 
     if (!response.data.ok) {
       logger.error(
@@ -162,25 +161,22 @@ export function copyUserInfoToDbMessageEntry(
 export async function fetchSlackChannelName(
   channelId: string
 ): Promise<string | null> {
-  const response = await axios.get('https://slack.com/api/conversations.info', {
+  const response = await slackAPI.get('conversations.info', {
     params: {
-      'Content-Type': 'application/json',
       channel: channelId,
       token: process.env.SLACK_BOT_ACCESS_TOKEN,
     },
   });
 
   if (response.data.ok) {
-    if (process.env.NODE_ENV !== 'test')
-      logger.info(
-        `SLACKAPIUTIL.fetchSlackChannelName: Successfully revealed Slack channel name (${channelId} -> ${response.data.channel.name})`
-      );
+    logger.info(
+      `SLACKAPIUTIL.fetchSlackChannelName: Successfully revealed Slack channel name (${channelId} -> ${response.data.channel.name})`
+    );
     return response.data.channel.name;
   } else {
-    if (process.env.NODE_ENV !== 'test')
-      logger.error(
-        `SLACKAPIUTIL.fetchSlackChannelName: Failed to reveal Slack channel name (${channelId}). Error: ${response.data.error}.`
-      );
+    logger.error(
+      `SLACKAPIUTIL.fetchSlackChannelName: Failed to reveal Slack channel name (${channelId}). Error: ${response.data.error}.`
+    );
     return null;
   }
 }
@@ -188,25 +184,22 @@ export async function fetchSlackChannelName(
 export async function fetchSlackUserName(
   userId: string
 ): Promise<string | null> {
-  const response = await axios.get('https://slack.com/api/users.info', {
+  const response = await slackAPI.get('users.info', {
     params: {
-      'Content-Type': 'application/json',
       user: userId,
       token: process.env.SLACK_BOT_ACCESS_TOKEN,
     },
   });
 
   if (response.data.ok) {
-    if (process.env.NODE_ENV !== 'test')
-      logger.info(
-        `SLACKAPIUTIL.fetchSlackUserName: Successfully revealed Slack user name (${userId} -> ${response.data.user.real_name})`
-      );
+    logger.info(
+      `SLACKAPIUTIL.fetchSlackUserName: Successfully revealed Slack user name (${userId} -> ${response.data.user.real_name})`
+    );
     return response.data.user.real_name;
   } else {
-    if (process.env.NODE_ENV !== 'test')
-      logger.error(
-        `SLACKAPIUTIL.fetchSlackUserName: Failed to reveal Slack user name (${userId}). Error: ${response.data.error}.`
-      );
+    logger.error(
+      `SLACKAPIUTIL.fetchSlackUserName: Failed to reveal Slack user name (${userId}). Error: ${response.data.error}.`
+    );
     return null;
   }
 }
@@ -216,49 +209,41 @@ export async function fetchSlackMessageBlocks(
   channelId: string,
   messageTs: string
 ): Promise<SlackBlock[] | null> {
-  const response = await axios.get(
-    'https://slack.com/api/conversations.history',
-    {
-      params: {
-        'Content-Type': 'application/json',
-        token: process.env.SLACK_BOT_ACCESS_TOKEN,
-        channel: channelId,
-        latest: messageTs,
-        inclusive: true,
-      },
-    }
-  );
+  const response = await slackAPI.get('conversations.history', {
+    params: {
+      token: process.env.SLACK_BOT_ACCESS_TOKEN,
+      channel: channelId,
+      latest: messageTs,
+      inclusive: true,
+    },
+  });
 
   if (response.data.ok) {
-    if (process.env.NODE_ENV !== 'test')
-      logger.info(
-        `SLACKAPIUTIL.fetchSlackMessageFirstBlockText: Successfully revealed Slack message text (${messageTs} -> ${response.data.messages[0].blocks[0].text.text})`
-      );
+    logger.info(
+      `SLACKAPIUTIL.fetchSlackMessageFirstBlockText: Successfully revealed Slack message text (${messageTs} -> ${response.data.messages[0].blocks[0].text.text})`
+    );
     return response.data.messages[0].blocks;
   } else {
-    if (process.env.NODE_ENV !== 'test')
-      logger.error(
-        `SLACKAPIUTIL.fetchSlackMessageFirstBlockText: Failed to reveal Slack message text (${messageTs}). Error: ${response.data.error}.`
-      );
+    logger.error(
+      `SLACKAPIUTIL.fetchSlackMessageFirstBlockText: Failed to reveal Slack message text (${messageTs}). Error: ${response.data.error}.`
+    );
     return null;
   }
 }
 
 export async function fetchSlackChannelNamesAndIds(): Promise<SlackChannelNamesAndIds | null> {
   logger.info(`ENTERING SLACKAPIUTIL.fetchSlackChannelNamesAndIds`);
-  const response = await axios.get('https://slack.com/api/conversations.list', {
+  const response = await slackAPI.get('conversations.list', {
     params: {
-      'Content-Type': 'application/json',
       token: process.env.SLACK_BOT_ACCESS_TOKEN,
       types: 'private_channel',
     },
   });
 
   if (response.data.ok) {
-    if (process.env.NODE_ENV !== 'test')
-      logger.info(
-        `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: Successfully fetched Slack channel names and IDs.`
-      );
+    logger.info(
+      `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: Successfully fetched Slack channel names and IDs.`
+    );
     const slackChannelNamesAndIds = {} as SlackChannelNamesAndIds;
     for (const idx in response.data.channels) {
       const channel = response.data.channels[idx];
@@ -267,10 +252,9 @@ export async function fetchSlackChannelNamesAndIds(): Promise<SlackChannelNamesA
     return slackChannelNamesAndIds;
     // return response.data.messages[0].blocks;
   } else {
-    if (process.env.NODE_ENV !== 'test')
-      logger.error(
-        `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: ERROR fetching Slack channel names and IDs. Error: ${response.data.error}.`
-      );
+    logger.error(
+      `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: ERROR fetching Slack channel names and IDs. Error: ${response.data.error}.`
+    );
     return null;
   }
 }
@@ -295,19 +279,11 @@ export async function addSlackMessageReaction(
   messageTs: string,
   reaction: string
 ): Promise<void> {
-  const response = await axios.post(
-    'https://slack.com/api/reactions.add',
-    {
-      channel: messageChannel,
-      timestamp: messageTs,
-      name: reaction,
-    },
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.SLACK_BOT_ACCESS_TOKEN}`,
-      },
-    }
-  );
+  const response = await slackAPI.post('reactions.add', {
+    channel: messageChannel,
+    timestamp: messageTs,
+    name: reaction,
+  });
 
   if (!response.data.ok) {
     throw new Error(
@@ -316,38 +292,58 @@ export async function addSlackMessageReaction(
   }
 }
 
+/**
+ * Renders a modal in slack and returns the modal ID
+ */
 export async function renderModal(
   triggerId: string,
   view: SlackView
-): Promise<void> {
+): Promise<string> {
   logger.info(`ENTERING SLACKAPIUTIL.renderModal`);
-  const response = await axios.post(
-    'https://slack.com/api/views.open',
-    {
-      'Content-Type': 'application/json',
-      trigger_id: triggerId,
-      view,
-    },
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.SLACK_BOT_ACCESS_TOKEN}`,
-      },
-    }
-  );
+  const response = await slackAPI.post('https://slack.com/api/views.open', {
+    trigger_id: triggerId,
+    view,
+  });
 
   if (response.data.ok) {
-    if (process.env.NODE_ENV !== 'test')
-      logger.info(
-        `SLACKAPIUTIL.renderModal: Successfully rendered modal (callback_id: ${view.callback_id}).`
-      );
-    return;
+    logger.info(
+      `SLACKAPIUTIL.renderModal: Successfully rendered modal (callback_id: ${view.callback_id}).`
+    );
+    return response.data.view.id;
   } else {
-    if (process.env.NODE_ENV !== 'test')
-      logger.error(
-        `SLACKAPIUTIL.renderModal: Failed to render modal (callback_id: ${view.callback_id}). Error: ${response.data.error}.`
-      );
+    logger.error(
+      `SLACKAPIUTIL.renderModal: Failed to render modal (callback_id: ${view.callback_id}). Error: ${response.data.error}.`
+    );
     throw new Error(
       `SLACKAPIUTIL.renderModal: Failed to render modal (callback_id: ${view.callback_id}). Error: ${response.data.error}.`
+    );
+  }
+}
+
+/**
+ * Updates a modal in slack given the modal ID from renderModal
+ */
+export async function updateModal(
+  viewId: string,
+  view: SlackView
+): Promise<string> {
+  logger.info(`ENTERING SLACKAPIUTIL.updateModal`);
+  const response = await slackAPI.post('https://slack.com/api/views.update', {
+    view_id: viewId,
+    view,
+  });
+
+  if (response.data.ok) {
+    logger.info(
+      `SLACKAPIUTIL.updateModal: Successfully updated modal (callback_id: ${view.callback_id}).`
+    );
+    return response.data.view.id;
+  } else {
+    logger.error(
+      `SLACKAPIUTIL.updateModal: Failed to update modal (callback_id: ${view.callback_id}). Error: ${response.data.error}.`
+    );
+    throw new Error(
+      `SLACKAPIUTIL.updateModal: Failed to update modal (callback_id: ${view.callback_id}). Error: ${response.data.error}.`
     );
   }
 }

--- a/src/slack_api_util.ts
+++ b/src/slack_api_util.ts
@@ -300,7 +300,7 @@ export async function renderModal(
   view: SlackView
 ): Promise<string> {
   logger.info(`ENTERING SLACKAPIUTIL.renderModal`);
-  const response = await slackAPI.post('https://slack.com/api/views.open', {
+  const response = await slackAPI.post('views.open', {
     trigger_id: triggerId,
     view,
   });
@@ -328,7 +328,7 @@ export async function updateModal(
   view: SlackView
 ): Promise<string> {
   logger.info(`ENTERING SLACKAPIUTIL.updateModal`);
-  const response = await slackAPI.post('https://slack.com/api/views.update', {
+  const response = await slackAPI.post('views.update', {
     view_id: viewId,
     view,
   });

--- a/src/slack_block_util.ts
+++ b/src/slack_block_util.ts
@@ -253,7 +253,15 @@ export function loadingSlackView(): SlackView {
       type: 'plain_text',
       text: 'Loading...',
     },
-    blocks: [],
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'Loading...',
+        },
+      },
+    ],
     type: 'modal',
   };
 }

--- a/src/slack_block_util.ts
+++ b/src/slack_block_util.ts
@@ -8,7 +8,7 @@ export type SlackBlock = {
 };
 
 export type SlackView = {
-  callback_id: string;
+  callback_id?: string;
   private_metadata?: string;
   title: {
     type: string;
@@ -18,15 +18,13 @@ export type SlackView = {
     type: string;
     text: string;
   };
-  blocks: [
-    {
+  blocks: {
+    type: string;
+    text: {
       type: string;
-      text: {
-        type: string;
-        text: string;
-      };
-    }
-  ];
+      text: string;
+    };
+  }[];
   type: 'modal';
 };
 
@@ -248,6 +246,17 @@ export const voterStatusPanel: SlackBlock = {
     },
   ],
 };
+
+export function loadingSlackView(): SlackView {
+  return {
+    title: {
+      type: 'plain_text',
+      text: 'Loading...',
+    },
+    blocks: [],
+    type: 'modal',
+  };
+}
 
 export function resetConfirmationSlackView(
   callbackId: string,

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -355,6 +355,7 @@ export async function receiveResetDemo({
   slackChannelName,
   userPhoneNumber,
   twilioPhoneNumber,
+  viewId,
 }: {
   payload: SlackInteractionEventPayload;
   redisClient: PromisifiedRedisClient;
@@ -362,6 +363,7 @@ export async function receiveResetDemo({
   slackChannelName: string;
   userPhoneNumber: string;
   twilioPhoneNumber: string;
+  viewId: string;
 }): Promise<void> {
   logger.info(`Entering SLACKINTERACTIONHANDLER.receiveResetDemo`);
   const MD5 = new Hashes.MD5();
@@ -434,7 +436,7 @@ export async function receiveResetDemo({
     );
   }
 
-  await SlackApiUtil.renderModal(payload.trigger_id, slackView);
+  await SlackApiUtil.updateModal(viewId, slackView);
 }
 
 // This function receives the confirmation of the resetting of

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -366,13 +366,16 @@ export async function receiveResetDemo({
   viewId: string;
 }): Promise<void> {
   logger.info(`Entering SLACKINTERACTIONHANDLER.receiveResetDemo`);
-  const MD5 = new Hashes.MD5();
-  const userId = MD5.hex(userPhoneNumber);
+  let slackView;
 
-  const commandType = 'RESET_DEMO';
-  // Ignore Prettier formatting because this object needs to adhere to JSON strigify requirements.
-  // prettier-ignore
-  const modalPrivateMetadata = {
+  try {
+    const MD5 = new Hashes.MD5();
+    const userId = MD5.hex(userPhoneNumber);
+
+    const commandType = 'RESET_DEMO';
+    // Ignore Prettier formatting because this object needs to adhere to JSON strigify requirements.
+    // prettier-ignore
+    const modalPrivateMetadata = {
     "commandType": commandType,
     "userId": userId,
     "userPhoneNumber": userPhoneNumber,
@@ -385,58 +388,69 @@ export async function receiveResetDemo({
     "actionTs": payload.action_ts
   } as SlackModalPrivateMetadata;
 
-  const redisUserInfoKey = `${userId}:${twilioPhoneNumber}`;
-  const userInfo = (await RedisApiUtil.getHash(
-    redisClient,
-    redisUserInfoKey
-  )) as UserInfo;
+    const redisUserInfoKey = `${userId}:${twilioPhoneNumber}`;
+    const userInfo = (await RedisApiUtil.getHash(
+      redisClient,
+      redisUserInfoKey
+    )) as UserInfo;
 
-  if (!userInfo) {
-    modalPrivateMetadata.success = false;
-    modalPrivateMetadata.failureReason = 'no_user_info';
-    await DbApiUtil.logCommandToDb(modalPrivateMetadata);
-    throw new Error(
-      `SLACKINTERACTIONHANDLER.receiveResetDemo: Interaction received for voter who has redisData but not userInfo: active redisData key is ${payload.channel.id}:${payload.message.ts}, userInfo key is ${redisUserInfoKey}.`
+    if (!userInfo) {
+      modalPrivateMetadata.success = false;
+      modalPrivateMetadata.failureReason = 'no_user_info';
+      await DbApiUtil.logCommandToDb(modalPrivateMetadata);
+      throw new Error(
+        `SLACKINTERACTIONHANDLER.receiveResetDemo: Interaction received for voter who has redisData but not userInfo: active redisData key is ${payload.channel.id}:${payload.message.ts}, userInfo key is ${redisUserInfoKey}.`
+      );
+    }
+
+    if (!userInfo.isDemo) {
+      modalPrivateMetadata.success = false;
+      modalPrivateMetadata.failureReason = 'non_demo';
+      await DbApiUtil.logCommandToDb(modalPrivateMetadata);
+      logger.info(
+        `SLACKINTERACTIONHANDLER.receiveResetDemo: Volunteer tried to reset demo on non-demo voter.`
+      );
+      slackView = SlackBlockUtil.getErrorSlackView(
+        'demo_reset_error_not_demo',
+        'This shortcut is strictly for demo conversations only. Please reach out to an admin for assistance.'
+      );
+    } else if (!(payload.channel.id === userInfo.activeChannelId)) {
+      modalPrivateMetadata.success = false;
+      modalPrivateMetadata.failureReason = 'non_active_thread';
+      await DbApiUtil.logCommandToDb(modalPrivateMetadata);
+      logger.info(
+        `SLACKINTERACTIONHANDLER.receiveResetDemo: Volunteer issued reset demo command from #${payload.channel.id} but voter active channel is ${userInfo.activeChannelId}.`
+      );
+      slackView = SlackBlockUtil.getErrorSlackView(
+        'demo_reset_error_not_active_thread',
+        `This voter is no longer active in this thread. Please reach out to the folks at *#${userInfo.activeChannelName}*.`
+      );
+    } else {
+      logger.info(
+        `SLACKINTERACTIONHANDLER.receiveResetDemo: Reset demo command is valid.`
+      );
+
+      // Store the relevant information in the modal so that when the requested action is confirmed
+      // the data needed for the necessary actions is available.
+      slackView = SlackBlockUtil.resetConfirmationSlackView(
+        commandType,
+        modalPrivateMetadata
+      );
+    }
+
+    await SlackApiUtil.updateModal(viewId, slackView);
+  } catch (e) {
+    // Update the modal to say that there was an error, then re-throw the
+    // error so it ends up in Sentry / the logs
+    await SlackApiUtil.updateModal(
+      viewId,
+      SlackBlockUtil.getErrorSlackView(
+        'internal_server_error',
+        'Sorry, something went wrong. Please try again.'
+      )
     );
+    throw e;
   }
-
-  let slackView;
-  if (!userInfo.isDemo) {
-    modalPrivateMetadata.success = false;
-    modalPrivateMetadata.failureReason = 'non_demo';
-    await DbApiUtil.logCommandToDb(modalPrivateMetadata);
-    logger.info(
-      `SLACKINTERACTIONHANDLER.receiveResetDemo: Volunteer tried to reset demo on non-demo voter.`
-    );
-    slackView = SlackBlockUtil.getErrorSlackView(
-      'demo_reset_error_not_demo',
-      'This shortcut is strictly for demo conversations only. Please reach out to an admin for assistance.'
-    );
-  } else if (!(payload.channel.id === userInfo.activeChannelId)) {
-    modalPrivateMetadata.success = false;
-    modalPrivateMetadata.failureReason = 'non_active_thread';
-    await DbApiUtil.logCommandToDb(modalPrivateMetadata);
-    logger.info(
-      `SLACKINTERACTIONHANDLER.receiveResetDemo: Volunteer issued reset demo command from #${payload.channel.id} but voter active channel is ${userInfo.activeChannelId}.`
-    );
-    slackView = SlackBlockUtil.getErrorSlackView(
-      'demo_reset_error_not_active_thread',
-      `This voter is no longer active in this thread. Please reach out to the folks at *#${userInfo.activeChannelName}*.`
-    );
-  } else {
-    logger.info(
-      `SLACKINTERACTIONHANDLER.receiveResetDemo: Reset demo command is valid.`
-    );
-
-    // Store the relevant information in the modal so that when the requested action is confirmed
-    // the data needed for the necessary actions is available.
-    slackView = SlackBlockUtil.resetConfirmationSlackView(
-      commandType,
-      modalPrivateMetadata
-    );
-  }
-
-  await SlackApiUtil.updateModal(viewId, slackView);
 }
 
 // This function receives the confirmation of the resetting of


### PR DESCRIPTION
@fongandrew Is this roughly what you had suggested to handle the 3-second timeout?

@tomerovadia -- I made a few updates to the `slack_api_utils`:
- Instead of checking for NODE_ENV == test, I updated `package.json` to set the logging level to FATAL in tests so we don't see any log messages (you can change this back to `info` or `debug` when debugging tests)
- I created a custom Axios instance that handles the Slack base URL and the headers for POST requests. `Content-Type` doesn't need to be in the request body (it's a header, not part of the request body) so I removed that from all of the API calls.