### PR TITLE
Add modal response for Slack user attempting Reset Demo on an invalid message

### DIFF
--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -50,7 +50,7 @@ async function slackInteractivityHandler(
     const redisHashKey = `${payload.channel.id}:${payload.message.ts}`;
     const redisData = await RedisApiUtil.getHash(redisClient, redisHashKey);
 
-    // Excempt message_action, which will be handled later by updating the Slack user's modal.
+    // Exempt message_action, which will be handled later by updating the Slack user's modal.
     if (!(payload.type === 'message_action')) {
       if (!originatingSlackChannelName) {
         throw new Error(
@@ -128,15 +128,15 @@ async function slackInteractivityHandler(
 
         if (!originatingSlackChannelName || !redisData) {
           modalPrivateMetadata.success = false;
-          modalPrivateMetadata.failureReason = 'not_active_voter_parent_thread';
+          modalPrivateMetadata.failureReason = 'invalid_shortcut_use';
           await DbApiUtil.logCommandToDb(modalPrivateMetadata);
           const slackView = SlackBlockUtil.getErrorSlackView(
             'not_active_voter_parent_thread',
-            'The Reset Demo shortcut is not valid on this message. Perhaps the voter has already been reset? Or this is not the first message in their thread?'
+            'This shortcut is not valid on this message.'
           );
           await SlackApiUtil.updateModal(viewId, slackView);
           logger.info(
-            `SLACKINTERACTIONHANDLER.receiveResetDemo: Volunteer tried to reset demo on an invalid Slack message.`
+            `SLACKINTERACTIONHANDLER.receiveResetDemo: Volunteer used a shortcut on an invalid message.`
           );
           return;
         }

--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -15,6 +15,9 @@ import * as SlackInteractionHandler from './slack_interaction_handler';
 import * as Router from './router';
 import logger from './logger';
 import redisClient from './redis_client';
+import Hashes from 'jshashes';
+import * as DbApiUtil from './db_api_util';
+import * as SlackBlockUtil from './slack_block_util';
 
 import {
   SlackInteractionEventPayload,
@@ -43,20 +46,23 @@ async function slackInteractivityHandler(
     const originatingSlackChannelName = await SlackApiUtil.fetchSlackChannelName(
       payload.channel.id
     );
-    if (!originatingSlackChannelName) {
-      throw new Error(
-        `Could not get slack channel name for Slack channel ${payload.channel.id}`
-      );
-    }
 
     const redisHashKey = `${payload.channel.id}:${payload.message.ts}`;
     const redisData = await RedisApiUtil.getHash(redisClient, redisHashKey);
 
-    if (!redisData) {
-      logger.debug(
-        `SERVER POST /slack-interactivity: Received an interaction for a voter who no longer exists in Redis.`
-      );
-      return;
+    // Excempt message_action, which will be handled later by updating the Slack user's modal.
+    if (!(payload.type === 'message_action')) {
+      if (!originatingSlackChannelName) {
+        throw new Error(
+          `Could not get slack channel name for Slack channel ${payload.channel.id}`
+        );
+      }
+      if (!redisData) {
+        logger.debug(
+          `SERVER POST /slack-interactivity: Received an interaction for a voter who no longer exists in Redis.`
+        );
+        return;
+      }
     }
 
     switch (payload.type) {
@@ -103,14 +109,45 @@ async function slackInteractivityHandler(
           );
         }
 
+        const MD5 = new Hashes.MD5();
+
+        // Ignore Prettier formatting because this object needs to adhere to JSON strigify requirements.
+        // prettier-ignore
+        const modalPrivateMetadata = {
+          "commandType": 'RESET_DEMO',
+          "userId": redisData ? MD5.hex(redisData.userPhoneNumber) : null,
+          "userPhoneNumber": redisData ? redisData.userPhoneNumber : null,
+          "twilioPhoneNumber": redisData ? redisData.twilioPhoneNumber : null,
+          "slackChannelId": payload.channel.id,
+          "slackParentMessageTs": payload.message.ts,
+          "originatingSlackUserName": originatingSlackUserName,
+          "originatingSlackUserId": payload.user.id,
+          "slackChannelName": originatingSlackChannelName,
+          "actionTs": payload.action_ts
+        } as SlackModalPrivateMetadata;
+
+        if (!originatingSlackChannelName || !redisData) {
+          modalPrivateMetadata.success = false;
+          modalPrivateMetadata.failureReason = 'not_active_voter_parent_thread';
+          await DbApiUtil.logCommandToDb(modalPrivateMetadata);
+          const slackView = SlackBlockUtil.getErrorSlackView(
+            'not_active_voter_parent_thread',
+            'The Reset Demo shortcut is not valid on this message. Perhaps the voter has already been reset? Or this is not the first message in their thread?'
+          );
+          await SlackApiUtil.updateModal(viewId, slackView);
+          logger.info(
+            `SLACKINTERACTIONHANDLER.receiveResetDemo: Volunteer tried to reset demo on an invalid Slack message.`
+          );
+          return;
+        }
+
         if (payload.callback_id === 'reset_demo') {
           await SlackInteractionHandler.receiveResetDemo({
             payload,
             redisClient,
-            originatingSlackUserName,
-            slackChannelName: originatingSlackChannelName,
-            userPhoneNumber: redisData ? redisData.userPhoneNumber : null,
+            modalPrivateMetadata,
             twilioPhoneNumber: redisData ? redisData.twilioPhoneNumber : null,
+            userId: MD5.hex(redisData.userPhoneNumber),
             viewId,
           });
           return;

--- a/src/slack_api_util.ts
+++ b/src/slack_api_util.ts
@@ -174,7 +174,7 @@ export async function fetchSlackChannelName(
     );
     return response.data.channel.name;
   } else {
-    logger.error(
+    logger.debug(
       `SLACKAPIUTIL.fetchSlackChannelName: Failed to reveal Slack channel name (${channelId}). Error: ${response.data.error}.`
     );
     return null;


### PR DESCRIPTION
During yesterday's volunteer training/demo, someone used the Reset Demo shortcut on a DM.

https://sentry.io/organizations/voteamerica/issues/1940442229/events/8da44c519d224f71b438dfec48bfa721/

This should add returning of a modal in cases where:
- User tries to Reset Demo on a voter thread but not the parent message
- User tries to Reset Demo on a voter parent message thread that has already been reset.