### PR TITLE
Add redis-backed deduplication to outbound sms

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -42,6 +42,7 @@ provider:
     CLIENT_ORGANIZATION: ${ssm:helpline.${self:custom.stage}.client_organization~true}
     DEMO_PHONE_NUMBER: ${ssm:helpline.${self:custom.stage}.demo_phone_number~true}
     REDISCLOUD_URL: ${ssm:helpline.${self:custom.stage}.redis_url~true}
+    REDISCLOUD_URL_DEDUPLICATION: ${ssm:helpline.${self:custom.stage}.redis_deduplication_url~true}
     DATABASE_URL: ${ssm:helpline.${self:custom.stage}.database_url~true}
     LAMBDA_BACKGROUND_TASK_FUNCTION: helpline-${self:custom.stage}-worker
 

--- a/src/deduplication.test.js
+++ b/src/deduplication.test.js
@@ -1,0 +1,13 @@
+jest.mock('redis', () => require('redis-mock'));
+
+import deduplicate from './deduplication';
+
+it('returns true and then false for a key', async () => {
+  expect(await deduplicate('foo')).toEqual(true);
+  expect(await deduplicate('foo')).toEqual(false);
+});
+
+it('returns true for different keys', async () => {
+  expect(await deduplicate('test1')).toEqual(true);
+  expect(await deduplicate('test2')).toEqual(true);
+});

--- a/src/deduplication.test.js
+++ b/src/deduplication.test.js
@@ -1,13 +1,13 @@
 jest.mock('redis', () => require('redis-mock'));
 
-import deduplicate from './deduplication';
+import isFirstUseOfKey from './deduplication';
 
 it('returns true and then false for a key', async () => {
-  expect(await deduplicate('foo')).toEqual(true);
-  expect(await deduplicate('foo')).toEqual(false);
+  expect(await isFirstUseOfKey('foo')).toEqual(true);
+  expect(await isFirstUseOfKey('foo')).toEqual(false);
 });
 
 it('returns true for different keys', async () => {
-  expect(await deduplicate('test1')).toEqual(true);
-  expect(await deduplicate('test2')).toEqual(true);
+  expect(await isFirstUseOfKey('test1')).toEqual(true);
+  expect(await isFirstUseOfKey('test2')).toEqual(true);
 });

--- a/src/deduplication.ts
+++ b/src/deduplication.ts
@@ -11,7 +11,7 @@ const DEDUPE_WINDOW_SECONDS = 60 * 60;
  * If there's an error talking to redis, it will return true (erring on the
  * side of permitting duplication if there's a problem with Redis).
  */
-export default async function deduplicate(key: string): Promise<boolean> {
+export default async function isFirstUseOfKey(key: string): Promise<boolean> {
   try {
     const res = await deduplicationRedisClient.setAsync(
       `deduplication:${key}`,
@@ -21,11 +21,7 @@ export default async function deduplicate(key: string): Promise<boolean> {
       'NX'
     );
 
-    if (res) {
-      return true;
-    } else {
-      return false;
-    }
+    return !!res;
   } catch (err) {
     logger.warn(`DEDUPLICATION: failed deduplicate message with key ${key}`);
     logger.warn(err);

--- a/src/deduplication.ts
+++ b/src/deduplication.ts
@@ -1,0 +1,35 @@
+import { deduplicationRedisClient } from './redis_client';
+import * as Sentry from '@sentry/node';
+
+const DEDUPE_WINDOW_SECONDS = 60 * 60;
+
+/**
+ * Implements redis-backed deduplication. The first time this is called with
+ * a given key, it will return true. After that, it will return false until
+ * the key expires in 1 hour.
+ *
+ * If there's an error talking to redis, it will return true (erring on the
+ * side of permitting duplication if there's a problem with Redis).
+ */
+export default async function deduplicate(key: string): Promise<boolean> {
+  try {
+    const res = await deduplicationRedisClient.setAsync(
+      `deduplication:${key}`,
+      'true',
+      'EX',
+      DEDUPE_WINDOW_SECONDS,
+      'NX'
+    );
+
+    if (res) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch (err) {
+    logger.warn(`DEDUPLICATION: failed deduplicate message with key ${key}`);
+    logger.warn(err);
+    Sentry.captureException(err);
+    return true;
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1091,7 +1091,12 @@ export async function handleSlackVoterThreadMessage(
 
     await TwilioApiUtil.sendMessage(
       messageToSend,
-      { userPhoneNumber, twilioPhoneNumber, twilioCallbackURL },
+      {
+        userPhoneNumber,
+        twilioPhoneNumber,
+        twilioCallbackURL,
+        deduplicationId: `${reqBody.event.channel}:${reqBody.event.ts}`,
+      },
       outboundDbMessageEntry
     );
     // Slack message is from inactive Slack thread.

--- a/src/twilio_api_util.ts
+++ b/src/twilio_api_util.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import * as DbApiUtil from './db_api_util';
 import logger from './logger';
 import twilio from 'twilio';
+import deduplicate from './deduplication';
 
 const twilioClient = twilio(
   process.env.TWILIO_ACCOUNT_SID,
@@ -14,6 +15,7 @@ export async function sendMessage(
     twilioPhoneNumber: string;
     userPhoneNumber: string;
     twilioCallbackURL: string;
+    deduplicationId?: string;
   },
   databaseMessageEntry?: DbApiUtil.DatabaseMessageEntry
 ): Promise<void> {
@@ -27,6 +29,31 @@ export async function sendMessage(
     databaseMessageEntry.fromPhoneNumber = options.twilioPhoneNumber;
     databaseMessageEntry.toPhoneNumber = options.userPhoneNumber;
     databaseMessageEntry.twilioSendTimestamp = new Date();
+  }
+
+  if (
+    options.deduplicationId &&
+    !(await deduplicate(options.deduplicationId))
+  ) {
+    logger.warn(
+      `TWILIOAPIUTIL.sendMessage: Not sending duplicate Twilio message to ${options.userPhoneNumber}: ${message}`
+    );
+
+    if (databaseMessageEntry) {
+      databaseMessageEntry.successfullySent = false;
+      databaseMessageEntry.twilioError = 'helpline_deduplication_filtered';
+
+      try {
+        await DbApiUtil.logMessageToDb(databaseMessageEntry);
+      } catch (error) {
+        logger.error(
+          'TWILIOAPIUTIL.sendMessage: failed to log message send duplication failure to DB'
+        );
+        Sentry.captureException(error);
+      }
+    }
+
+    return;
   }
 
   try {


### PR DESCRIPTION
- Pass a unique slack message ID to the twilio sendMessage function to use as a deduplication ID
- Deduplicate outbound twilio messages when a deduplication ID is provided