### PR TITLE
Reorder states so we prioritize IN and OK below other states during parsing

### DIFF
--- a/src/state_constants.ts
+++ b/src/state_constants.ts
@@ -16,7 +16,6 @@ export function getStateConstants(): { [stateCode: string]: string } {
         HI: 'Hawaii',
         ID: 'Idaho',
         IL: 'Illinois',
-        IN: 'Indiana',
         IA: 'Iowa',
         KS: 'Kansas',
         KY: 'Kentucky',
@@ -38,7 +37,6 @@ export function getStateConstants(): { [stateCode: string]: string } {
         NC: 'North Carolina',
         ND: 'North Dakota',
         OH: 'Ohio',
-        OK: 'Oklahoma',
         OR: 'Oregon',
         PA: 'Pennsylvania',
         RI: 'Rhode Island',
@@ -53,6 +51,8 @@ export function getStateConstants(): { [stateCode: string]: string } {
         WV: 'West Virginia',
         WI: 'Wisconsin',
         WY: 'Wyoming',
+        IN: 'Indiana',
+        OK: 'Oklahoma',
       };
     case 'VOTER_HELP_LINE':
       return {

--- a/src/state_parser.test.js
+++ b/src/state_parser.test.js
@@ -1,5 +1,9 @@
 const StateParser = require('./state_parser');
 
+beforeEach(() => {
+  process.env.CLIENT_ORGANIZATION = 'VOTE_AMERICA';
+});
+
 test('Identifies exact state abbreviation.', () => {
   expect(StateParser.determineState('NC')).toBe('North Carolina');
 });
@@ -139,4 +143,16 @@ test('Handles abbreviation of only name part, with period.', () => {
   expect(StateParser.determineState('I want to vote in N.Carolina')).toBe(
     'North Carolina'
   );
+});
+
+test('Prioritizes OK lower than everything else except IN', () => {
+  expect(StateParser.determineState("OK, I'm in IN")).toBe('Indiana');
+});
+
+test('Prioritizes IN lower than everything else', () => {
+  expect(
+    StateParser.determineState(
+      "OK, I'm registered to vote in NJ but I live in MD"
+    )
+  ).toBe('Maryland');
 });


### PR DESCRIPTION
So we only categorize a state as Indiana (IN) or Oklahoma (OK) if they don't match any other states.