### PR TITLE
Have SlackApiUtil use pagination for conversations.list lookup

### DIFF
--- a/src/slack_api_util.ts
+++ b/src/slack_api_util.ts
@@ -269,6 +269,7 @@ export async function fetchSlackChannelNamesAndIds(): Promise<SlackChannelNamesA
   let channels = firstPageResponse.data.channels;
   let cursor = firstPageResponse.data.response_metadata.next_cursor;
   // Slack will return a (falsy) empty string when there is no next page.
+  // See 'Pagination' on this reference: https://api.slack.com/methods/conversations.list
   while (cursor) {
     logger.info(
       `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: Fetching subsequent page of Slack channel names and IDs (cursor: ${cursor}).`

--- a/src/slack_api_util.ts
+++ b/src/slack_api_util.ts
@@ -247,28 +247,53 @@ export async function fetchSlackMessageBlocks(
 
 export async function fetchSlackChannelNamesAndIds(): Promise<SlackChannelNamesAndIds | null> {
   logger.info(`ENTERING SLACKAPIUTIL.fetchSlackChannelNamesAndIds`);
-  const response = await slackAPI.get('conversations.list', {
+  const firstPageResponse = await slackAPI.get('conversations.list', {
     params: {
       token: process.env.SLACK_BOT_ACCESS_TOKEN,
       types: 'private_channel',
     },
   });
 
-  if (response.data.ok) {
+  if (firstPageResponse.data.ok) {
     logger.info(
-      `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: Successfully fetched Slack channel names and IDs.`
+      `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: Successfully fetched first page of Slack channel names and IDs.`
     );
+
+    let channels = firstPageResponse.data.channels;
+    let cursor = firstPageResponse.data.response_metadata.next_cursor;
+    // Slack will return a (falsy) empty string when there is no next page.
+    while (cursor) {
+      const subsequentPageResponse = await slackAPI.get('conversations.list', {
+        params: {
+          token: process.env.SLACK_BOT_ACCESS_TOKEN,
+          types: 'private_channel',
+          cursor,
+        },
+      });
+
+      if (subsequentPageResponse.data.ok) {
+        cursor = subsequentPageResponse.data.response_metadata.next_cursor;
+        channels = channels.concat(subsequentPageResponse.data.channels);
+      } else {
+        logger.error(
+          `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: ERROR fetching subsequent page of Slack channel names and IDs. Error: response.data: ${JSON.stringify(
+            firstPageResponse.data
+          )}`
+        );
+        break;
+      }
+    }
+
     const slackChannelNamesAndIds = {} as SlackChannelNamesAndIds;
-    for (const idx in response.data.channels) {
-      const channel = response.data.channels[idx];
+    for (const idx in channels) {
+      const channel = channels[idx];
       slackChannelNamesAndIds[channel.name] = channel.id;
     }
     return slackChannelNamesAndIds;
-    // return response.data.messages[0].blocks;
   } else {
     logger.error(
-      `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: ERROR fetching Slack channel names and IDs. Error: response.data: ${JSON.stringify(
-        response.data
+      `SLACKAPIUTIL.fetchSlackChannelNamesAndIds: ERROR fetching initial page of Slack channel names and IDs. Error: response.data: ${JSON.stringify(
+        firstPageResponse.data
       )}`
     );
     return null;

--- a/src/state_region_config.ts
+++ b/src/state_region_config.ts
@@ -8,7 +8,7 @@ export const stateToRegionMap: { [stateCode: string]: string } = {
   Connecticut: 'Eastern North',
   Delaware: 'Eastern North',
   'District of Columbia': 'Eastern South',
-  Florida: 'Eastern South',
+  Florida: 'Florida',
   Georgia: 'Eastern South',
   Hawaii: 'Pacific',
   Idaho: 'Mountain',

--- a/src/state_region_config.ts
+++ b/src/state_region_config.ts
@@ -8,7 +8,7 @@ export const stateToRegionMap: { [stateCode: string]: string } = {
   Connecticut: 'Eastern North',
   Delaware: 'Eastern North',
   'District of Columbia': 'Eastern South',
-  Florida: 'Florida',
+  Florida: 'Eastern South',
   Georgia: 'Eastern South',
   Hawaii: 'Pacific',
   Idaho: 'Mountain',


### PR DESCRIPTION
@benweissmann noticed that we only get the first page of Slack channels using `conversation.list` when needing to update Redis's cache of Slack channel names->ids (see Pagination on [this page](https://api.slack.com/methods/conversations.list)).

This change updates the `conversation.list` call to use response_metadata.cursor to make additional calls to fetch additional pages of channels.

This fixes a bug with the `ROUTE_VOTER` command in which it sometimes does not recognize a valid name for an existing channel.

It also fixes a bug that would occur if a voter were re-routed back to a channel that they have visited before, and that channel were not already in the cache. Previously, the voter would be treated as a new voter in that channel (new thread). Now, they will be re-routed back to their previous thread.