### PR TITLE
Add back names of volunteers in message history

### DIFF
--- a/src/slack_message_formatter.ts
+++ b/src/slack_message_formatter.ts
@@ -27,14 +27,14 @@ export function formatMessageHistory(
       );
     } else if (messageObject.automated) {
       return (
-        ':gear: *Helpline*  ' +
+        ':gear: *Helpline (Automated)*  ' +
         specialSlackTimestamp +
         '\n' +
         formatMessageBlock(messageObject.message, '_')
       );
     } else {
       return (
-        ':adult: *Helpline*  ' +
+        `:adult: *${messageObject.originating_slack_user_name} (Volunteer)*  ` +
         specialSlackTimestamp +
         '\n' +
         formatMessageBlock(messageObject.message, '')


### PR DESCRIPTION
Just caught that the improved message history format drops inclusion of volunteer names, which is there for the purpose of being able to DM a voter's previous volunteer(s) if collaboration on a voter's situation is necessary.