### PR TITLE
Improve state parser handling of OK, IN, ME and OR U.S. state abbreviations

### DIFF
--- a/src/state_constants.ts
+++ b/src/state_constants.ts
@@ -20,7 +20,6 @@ export function getStateConstants(): { [stateCode: string]: string } {
         KS: 'Kansas',
         KY: 'Kentucky',
         LA: 'Louisiana',
-        ME: 'Maine',
         MD: 'Maryland',
         MA: 'Massachusetts',
         MI: 'Michigan',
@@ -37,7 +36,6 @@ export function getStateConstants(): { [stateCode: string]: string } {
         NC: 'North Carolina',
         ND: 'North Dakota',
         OH: 'Ohio',
-        OR: 'Oregon',
         PA: 'Pennsylvania',
         RI: 'Rhode Island',
         SC: 'South Carolina',
@@ -53,6 +51,8 @@ export function getStateConstants(): { [stateCode: string]: string } {
         WY: 'Wyoming',
         IN: 'Indiana',
         OK: 'Oklahoma',
+        ME: 'Maine',
+        OR: 'Oregon',
       };
     case 'VOTER_HELP_LINE':
       return {

--- a/src/state_parser.test.js
+++ b/src/state_parser.test.js
@@ -145,14 +145,80 @@ test('Handles abbreviation of only name part, with period.', () => {
   );
 });
 
-test('Prioritizes OK lower than everything else except IN', () => {
-  expect(StateParser.determineState("OK, I'm in IN")).toBe('Indiana');
-});
-
-test('Prioritizes IN lower than everything else', () => {
+test('Adds extra scrutiny to "in", "me", "ok" and "or", not considering them to be U.S. state mentions in the context of longer messages', () => {
   expect(
     StateParser.determineState(
-      "OK, I'm registered to vote in NJ but I live in MD"
+      "Mail-in ballot"
     )
-  ).toBe('Maryland');
+  ).toBe(null);
+
+  expect(
+    StateParser.determineState(
+      "Either send me the form, or remove from your mailing list."
+    )
+  ).toBe(null);
+
+  expect(
+    StateParser.determineState(
+      "I need to make sure that my ballot is ok"
+    )
+  ).toBe(null);
+
+  expect(
+    StateParser.determineState(
+      "Can you help me vote?"
+    )
+  ).toBe(null);
+});
+
+test('Does recognize "in", "ok", "me" and "or" as U.S. state preferences when alone in a message, excluding spaces', () => {
+  expect(
+    StateParser.determineState(
+      "in "
+    )
+  ).toBe('Indiana');
+
+  expect(
+    StateParser.determineState(
+      "O.K. "
+    )
+  ).toBe('Oklahoma');
+
+  expect(
+    StateParser.determineState(
+      " ME "
+    )
+  ).toBe('Maine');
+
+  expect(
+    StateParser.determineState(
+      " Or    "
+    )
+  ).toBe('Oregon');
+});
+
+test('Does recognize "Indiana", "Oklahoma", "Maine" and "Oregon" normally, even in the context of a longer message', () => {
+  expect(
+    StateParser.determineState(
+      "Send me to Oklahoma"
+    )
+  ).toBe('Oklahoma');
+
+  expect(
+    StateParser.determineState(
+      "I'm in Maine"
+    )
+  ).toBe('Maine');
+
+  expect(
+    StateParser.determineState(
+      "Ok let's do Indiana"
+    )
+  ).toBe('Indiana');
+
+  expect(
+    StateParser.determineState(
+      "Ok Oregon"
+    )
+  ).toBe('Oregon');
 });

--- a/src/state_parser.test.js
+++ b/src/state_parser.test.js
@@ -146,79 +146,37 @@ test('Handles abbreviation of only name part, with period.', () => {
 });
 
 test('Adds extra scrutiny to "in", "me", "ok" and "or", not considering them to be U.S. state mentions in the context of longer messages', () => {
+  expect(StateParser.determineState('Mail-in ballot')).toBe(null);
+
   expect(
     StateParser.determineState(
-      "Mail-in ballot"
+      'Either send me the form, or remove from your mailing list.'
     )
   ).toBe(null);
 
   expect(
-    StateParser.determineState(
-      "Either send me the form, or remove from your mailing list."
-    )
+    StateParser.determineState('I need to make sure that my ballot is ok')
   ).toBe(null);
 
-  expect(
-    StateParser.determineState(
-      "I need to make sure that my ballot is ok"
-    )
-  ).toBe(null);
-
-  expect(
-    StateParser.determineState(
-      "Can you help me vote?"
-    )
-  ).toBe(null);
+  expect(StateParser.determineState('Can you help me vote?')).toBe(null);
 });
 
 test('Does recognize "in", "ok", "me" and "or" as U.S. state preferences when alone in a message, excluding spaces', () => {
-  expect(
-    StateParser.determineState(
-      "in "
-    )
-  ).toBe('Indiana');
+  expect(StateParser.determineState('in ')).toBe('Indiana');
 
-  expect(
-    StateParser.determineState(
-      "O.K. "
-    )
-  ).toBe('Oklahoma');
+  expect(StateParser.determineState('O.K. ')).toBe('Oklahoma');
 
-  expect(
-    StateParser.determineState(
-      " ME "
-    )
-  ).toBe('Maine');
+  expect(StateParser.determineState(' ME ')).toBe('Maine');
 
-  expect(
-    StateParser.determineState(
-      " Or    "
-    )
-  ).toBe('Oregon');
+  expect(StateParser.determineState(' Or    ')).toBe('Oregon');
 });
 
 test('Does recognize "Indiana", "Oklahoma", "Maine" and "Oregon" normally, even in the context of a longer message', () => {
-  expect(
-    StateParser.determineState(
-      "Send me to Oklahoma"
-    )
-  ).toBe('Oklahoma');
+  expect(StateParser.determineState('Send me to Oklahoma')).toBe('Oklahoma');
 
-  expect(
-    StateParser.determineState(
-      "I'm in Maine"
-    )
-  ).toBe('Maine');
+  expect(StateParser.determineState("I'm in Maine")).toBe('Maine');
 
-  expect(
-    StateParser.determineState(
-      "Ok let's do Indiana"
-    )
-  ).toBe('Indiana');
+  expect(StateParser.determineState("Ok let's do Indiana")).toBe('Indiana');
 
-  expect(
-    StateParser.determineState(
-      "Ok Oregon"
-    )
-  ).toBe('Oregon');
+  expect(StateParser.determineState('Ok Oregon')).toBe('Oregon');
 });

--- a/src/state_parser.ts
+++ b/src/state_parser.ts
@@ -48,7 +48,10 @@ export function determineState(userMessage: string): string | null {
     // sought.
     if (['IN', 'OK', 'ME', 'OR'].includes(abbrev)) {
       // Remove spaces in case message is state abbreviation plus spaces and punctuation (e.g. "O.K. ")
-      const userMessageNoPunctuationOrSpaces = userMessageNoPunctuation.replace(/\s/g, '');
+      const userMessageNoPunctuationOrSpaces = userMessageNoPunctuation.replace(
+        /\s/g,
+        ''
+      );
       if (userMessageNoPunctuationOrSpaces.length > 2) {
         continue;
       }


### PR DESCRIPTION
Specifically: don't recognize those four U.S. state abbreviations, which are also common English words, as U.S. states if they're in the context of a longer message. Also, lower ME and OR in the priority of states checked.

This change errs on the side of not recognizing a U.S. state selection so that admins can correct, instead of incorrectly recognizing a U.S. state, which calls for an apology.

Note: I don't believe check priority matters after this change, since this change makes it so that the abbreviations OK, IN, ME and OR are not recognized as referring to a U.S. state if the message is longer than 2 characters (excluding spaces and punctuation).