### PR TITLE
Use a custom username/profile image when posting voter messages

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -267,7 +267,11 @@ const introduceNewVoterToSlackChannel = async (
     );
     await SlackApiUtil.sendMessage(
       `${userMessage}`,
-      { parentMessageTs: response.data.ts, channel: response.data.channel },
+      {
+        parentMessageTs: response.data.ts,
+        channel: response.data.channel,
+        isVoterMessage: true,
+      },
       inboundDbMessageEntry,
       userInfo
     );
@@ -809,7 +813,11 @@ export async function determineVoterState(
   );
   await SlackApiUtil.sendMessage(
     `${userMessage}`,
-    { parentMessageTs: lobbyParentMessageTs, channel: lobbyChannelId },
+    {
+      parentMessageTs: lobbyParentMessageTs,
+      channel: lobbyChannelId,
+      isVoterMessage: true,
+    },
     inboundDbMessageEntry,
     userInfo
   );
@@ -970,7 +978,7 @@ export async function handleDisclaimer(
 
   await SlackApiUtil.sendMessage(
     `${userMessage}`,
-    slackLobbyMessageParams,
+    { ...slackLobbyMessageParams, isVoterMessage: true },
     inboundDbMessageEntry,
     userInfo
   );
@@ -1037,7 +1045,7 @@ export async function handleClearedVoter(
 
   await SlackApiUtil.sendMessage(
     `${userOptions.userMessage}`,
-    activeChannelMessageParams,
+    { ...activeChannelMessageParams, isVoterMessage: true },
     inboundDbMessageEntry,
     userInfo
   );

--- a/src/slack_api_util.ts
+++ b/src/slack_api_util.ts
@@ -30,6 +30,7 @@ type SlackSendMessageOptions = {
   unfurl_links?: boolean;
   unfurl_media?: boolean;
   blocks?: SlackBlock[];
+  isVoterMessage?: boolean;
 };
 
 type SlackChannelNamesAndIds = {
@@ -129,14 +130,21 @@ export async function sendMessage(
   }
 
   try {
-    const response = await slackAPI.post('chat.postMessage', {
+    const slackArgs = {
       channel: options.channel,
       text: message,
       token: process.env.SLACK_BOT_ACCESS_TOKEN,
       thread_ts: options.parentMessageTs,
       blocks: options.blocks,
       unfurl_media: false,
-    });
+    } as { [key: string]: any };
+
+    if (options.isVoterMessage) {
+      slackArgs.username = `Voter ${userInfo?.userId.substring(0, 5)}`;
+      slackArgs.icon_emoji = ':bust_in_silhouette:';
+    }
+
+    const response = await slackAPI.post('chat.postMessage', slackArgs);
 
     if (!response.data.ok) {
       logger.error(


### PR DESCRIPTION
- Add a feature to SlackApiUtils.sendMessage to use a username/profile pic for the voter rather than the bot
- Turn this on for everywhere we relay voter messages

I went over every call to SlackAPiUtils.sendMessage to see whether i should pass `isVoterMessage`, but please take another look at this -- I don't know the code as well as you so I'm not sure if I missed anywhere.