### PR TITLE
Fix how LoadBalancer falls back when Redis doesn't have data on open pods

### DIFF
--- a/src/load_balancer.ts
+++ b/src/load_balancer.ts
@@ -105,7 +105,7 @@ export async function selectSlackChannel(
     0,
     -1 /* max # of pods */
   );
-  if (!openPods) {
+  if (!openPods || openPods.length === 0) {
     logger.error(
       `LOADBALANCER.selectSlackChannel: ERROR finding openPodsKey ${openPodsKey} in Redis: err || !openPods`
     );


### PR DESCRIPTION
If Redis doesn't have data on an entrypoint it returns an empty array, which is truthy. In addition to checking if a truthy value was returned, this PR has the LoadBalancer check if the truthy return value is an empty array, and log an error if so (with fallback to national channels).