### PR TITLE
feat: do not tag users in clear-attention callback

### DIFF
--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -162,7 +162,7 @@ async function slackInteractivityHandler(
           false
         );
         await SlackApiUtil.sendMessage(
-          `*Operator:* *Needs Attention* cleared by <@${payload.user.id}>`,
+          `*Operator:* *Needs Attention* cleared by ${payload.user.id}`,
           {
             parentMessageTs: payload.message.thread_ts || payload.message.ts,
             channel: payload.channel.id,


### PR DESCRIPTION
Tagging users when they clear `Needs Attention` can be disruptive to workflow. Currently, volunteers receive a tag shortly after they've "cleared" a thread - pulling them back into it (with a notification!) just after they've moved on. This PR makes it so that the volunteer will be mentioned - but not tagged - when they clear `Needs Attention`.

The downside of not tagging volunteers is that Slack will no longer track any username changes to ensure this message is always pointing at a logical user. This is likely an acceptable tradeoff to permit a smoother workflow for volunteers.