### PR TITLE
fix(needs-attention): use fetched username rather than id

### DIFF
--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -156,7 +156,7 @@ async function slackInteractivityHandler(
           true
         );
         await SlackApiUtil.sendMessage(
-          `*Operator:* Thread marked as *Needs Attention* by <@${payload.user.id}>`,
+          `*Operator:* Thread marked as *Needs Attention* by ${originatingSlackUserName}`,
           {
             parentMessageTs: payload.message.thread_ts || payload.message.ts,
             channel: payload.channel.id,
@@ -173,7 +173,7 @@ async function slackInteractivityHandler(
           false
         );
         await SlackApiUtil.sendMessage(
-          `*Operator:* *Needs Attention* cleared by ${payload.user.id}`,
+          `*Operator:* *Needs Attention* cleared by ${originatingSlackUserName}`,
           {
             parentMessageTs: payload.message.thread_ts || payload.message.ts,
             channel: payload.channel.id,


### PR DESCRIPTION
In #155 we updated the response for when needs-attention was cleared to not tag a user. Unfortunately, we left the plaintext `user.id` in the response, which isn't human-readable. Sorry about that.

This fixes both needs-attention related posts to use `originatingSlackUserName`, which is fetched earlier in the handler. This should be human-readable - and consistent with other messages!

One note: Based on the [Shortcuts payload docs](https://api.slack.com/reference/interaction-payloads/shortcuts), both global and message shortcuts include a `user` object in their payload. This [`user` object has a `name` field](https://api.slack.com/types/user), so we may be able to save a call to Slack. I did not pursue this refactor because I don't have an easy way to test locally, and because [the listed examples are inconsistent as to whether the field is `user.name` or `user.username`](https://api.slack.com/reference/interaction-payloads/shortcuts#reference-shortcuts-interaction-payloads__examples).