### PR TITLE
Update how STOP keyword is detected

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -410,7 +410,7 @@ const handleIncomingTwilioMessage = async (
       `SERVER.handleIncomingTwilioMessage (${userId}): Voter is new to us (Redis returned no userInfo for redisHashKey ${redisHashKey})`
     );
 
-    if (KeywordParser.isStopKeyword(userMessage)) {
+    if (KeywordParser.containsStopKeyword(userMessage)) {
       logger.info(
         `SERVER.handleIncomingTwilioMessage: Received STOP text from phone number: ${userPhoneNumber}.`
       );

--- a/src/keyword_parser.test.js
+++ b/src/keyword_parser.test.js
@@ -1,0 +1,38 @@
+const KeywordParser = require('./keyword_parser');
+
+test('Does not consider a normal message to contain STOP keyword.', () => {
+  expect(KeywordParser.containsStopKeyword('Some normal message')).toBe(false);
+});
+
+test('Detects STOP keyword.', () => {
+    expect(KeywordParser.containsStopKeyword('STOP')).toBe(true);
+});
+
+test('Detects STOP keyword with spaces on either side.', () => {
+    expect(KeywordParser.containsStopKeyword('  STOP   ')).toBe(true);
+});
+
+test('Does not detect STOP keyword with spaces within the word.', () => {
+    expect(KeywordParser.containsStopKeyword('VOTING IS TOP OF MIND FOR ME YAY')).toBe(false);
+});
+
+test('Detects STOP keyword with punctuation.', () => {
+    expect(KeywordParser.containsStopKeyword('STOP!')).toBe(true);
+});
+
+test('Detects STOP keyword in any upper/lower case.', () => {
+    expect(KeywordParser.containsStopKeyword('stop')).toBe(true);
+    expect(KeywordParser.containsStopKeyword('StOp')).toBe(true);
+});
+
+test('Detects STOP keyword alone in any upper/lower case even with punctuation.', () => {
+    expect(KeywordParser.containsStopKeyword('stop!!')).toBe(true);
+});
+
+test('Does not detect lowercase stop in the context of a longer message if lowercase.', () => {
+    expect(KeywordParser.containsStopKeyword("I'll stop by the polling place on the way to work")).toBe(false);
+});
+
+test('Detects STOP keyword in the context of longer message if in all uppercase.', () => {
+    expect(KeywordParser.containsStopKeyword("That's what I am telling you, I have done what you told me to do to unsubscribe and YOU ARE STILL CONTACTING ME. STOP IT!!")).toBe(true);
+});

--- a/src/keyword_parser.test.js
+++ b/src/keyword_parser.test.js
@@ -5,34 +5,46 @@ test('Does not consider a normal message to contain STOP keyword.', () => {
 });
 
 test('Detects STOP keyword.', () => {
-    expect(KeywordParser.containsStopKeyword('STOP')).toBe(true);
+  expect(KeywordParser.containsStopKeyword('STOP')).toBe(true);
 });
 
 test('Detects STOP keyword with spaces on either side.', () => {
-    expect(KeywordParser.containsStopKeyword('  STOP   ')).toBe(true);
+  expect(KeywordParser.containsStopKeyword('  STOP   ')).toBe(true);
 });
 
 test('Does not detect STOP keyword with spaces within the word.', () => {
-    expect(KeywordParser.containsStopKeyword('VOTING IS TOP OF MIND FOR ME YAY')).toBe(false);
+  expect(
+    KeywordParser.containsStopKeyword('VOTING IS TOP OF MIND FOR ME YAY')
+  ).toBe(false);
 });
 
 test('Detects STOP keyword with punctuation.', () => {
-    expect(KeywordParser.containsStopKeyword('STOP!')).toBe(true);
+  expect(KeywordParser.containsStopKeyword('STOP!')).toBe(true);
 });
 
 test('Detects STOP keyword in any upper/lower case.', () => {
-    expect(KeywordParser.containsStopKeyword('stop')).toBe(true);
-    expect(KeywordParser.containsStopKeyword('StOp')).toBe(true);
+  expect(KeywordParser.containsStopKeyword('stop')).toBe(true);
+  expect(KeywordParser.containsStopKeyword('StOp')).toBe(true);
 });
 
 test('Detects STOP keyword alone in any upper/lower case even with punctuation.', () => {
-    expect(KeywordParser.containsStopKeyword('stop!!')).toBe(true);
+  expect(KeywordParser.containsStopKeyword('stop!!')).toBe(true);
+  expect(KeywordParser.containsStopKeyword('Stop!!')).toBe(true);
+  expect(KeywordParser.containsStopKeyword('S.T.O.P.')).toBe(true);
 });
 
 test('Does not detect lowercase stop in the context of a longer message if lowercase.', () => {
-    expect(KeywordParser.containsStopKeyword("I'll stop by the polling place on the way to work")).toBe(false);
+  expect(
+    KeywordParser.containsStopKeyword(
+      "I'll stop by the polling place on the way to work"
+    )
+  ).toBe(false);
 });
 
 test('Detects STOP keyword in the context of longer message if in all uppercase.', () => {
-    expect(KeywordParser.containsStopKeyword("That's what I am telling you, I have done what you told me to do to unsubscribe and YOU ARE STILL CONTACTING ME. STOP IT!!")).toBe(true);
+  expect(
+    KeywordParser.containsStopKeyword(
+      "That's what I am telling you, I have done what you told me to do to unsubscribe and YOU ARE STILL CONTACTING ME. STOP IT!!"
+    )
+  ).toBe(true);
 });

--- a/src/keyword_parser.ts
+++ b/src/keyword_parser.ts
@@ -6,22 +6,23 @@ export function isHelplineKeyword(userMessage: string): boolean {
 }
 
 export function containsStopKeyword(userMessage: string): boolean {
-  const userMessageTrimmedNoPunctuation = userMessage.trim().replace(/[^a-zA-Z\s]/g, '');
-
-  const userMessageLowercaseNoPunctuationOrSpaces = userMessageTrimmedNoPunctuation
-    .toLowerCase()
-    .replace(/\s/g, '');
+  const userMessageTrimmedNoPunctuation = userMessage
+    .trim()
+    .replace(/[^a-zA-Z\s]/g, '');
 
   // Catches a one-word message that is simply STOP (including any case, catching e.g. Stop),
   // and disregarding punctuation (catching e.g. STOP!!!).
-  const isStopAnyCase = userMessageLowercaseNoPunctuationOrSpaces === 'stop';
+  const isStopAnyCase =
+    userMessageTrimmedNoPunctuation.toLowerCase().replace(/\s/g, '') === 'stop';
 
-  // Important: Unlike the above parsing. This one does not remove spaces.
-  // It also preserves case.    
+  // Important: Unlike the above parsing, this one does not remove spaces.
+  // It also preserves case.
   // Catches a message that contains STOP in all uppercase even in the context
   // of a longer message.
-  const containsStopUppercase = userMessageTrimmedNoPunctuation.split(" ").includes('STOP');
-  
+  const containsStopUppercase = userMessageTrimmedNoPunctuation
+    .split(' ')
+    .includes('STOP');
+
   return isStopAnyCase || containsStopUppercase;
 }
 

--- a/src/keyword_parser.ts
+++ b/src/keyword_parser.ts
@@ -1,12 +1,28 @@
 export function isHelplineKeyword(userMessage: string): boolean {
-  const userMessageNoPunctuation = userMessage
+  const userMessageSanitized = userMessage
     .toLowerCase()
     .replace(/[^a-zA-Z]/g, '');
-  return userMessageNoPunctuation.startsWith('helpline');
+  return userMessageSanitized.startsWith('helpline');
 }
 
-export function isStopKeyword(userMessage: string): boolean {
-  return userMessage.toLowerCase().trim() === 'stop';
+export function containsStopKeyword(userMessage: string): boolean {
+  const userMessageTrimmedNoPunctuation = userMessage.trim().replace(/[^a-zA-Z\s]/g, '');
+
+  const userMessageLowercaseNoPunctuationOrSpaces = userMessageTrimmedNoPunctuation
+    .toLowerCase()
+    .replace(/\s/g, '');
+
+  // Catches a one-word message that is simply STOP (including any case, catching e.g. Stop),
+  // and disregarding punctuation (catching e.g. STOP!!!).
+  const isStopAnyCase = userMessageLowercaseNoPunctuationOrSpaces === 'stop';
+
+  // Important: Unlike the above parsing. This one does not remove spaces.
+  // It also preserves case.    
+  // Catches a message that contains STOP in all uppercase even in the context
+  // of a longer message.
+  const containsStopUppercase = userMessageTrimmedNoPunctuation.split(" ").includes('STOP');
+  
+  return isStopAnyCase || containsStopUppercase;
 }
 
 export function isVotedKeyword(userMessage: string): boolean {


### PR DESCRIPTION
In particular, loosen rule to include two additional circumstances:
1) STOP with punctuation
2) STOP in all caps in context of a longer message