### PR TITLE
Have Redis update sooner when a voter is routed between channels

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -480,6 +480,24 @@ const routeVoterToSlackChannelHelper = async (
                 destinationSlackParentMessageTs: ${destinationSlackParentMessageTs},
                 destinationSlackChannelName: ${destinationSlackChannelName}`);
 
+  logger.debug(
+    "ROUTER.routeVoterToSlackChannelHelper: Changing voter's active channel."
+  );
+  // Reassign the active channel so that the next voter messages go to the
+  // new active channel.
+  userInfo.activeChannelId = destinationSlackChannelId;
+  userInfo.activeChannelName = destinationSlackChannelName;
+
+  // Update userInfo in Redis (remember state channel thread identifying info and new activeChannel).
+  logger.debug(
+    `ROUTER.routeVoterToSlackChannelHelper: Writing updated userInfo to Redis.`
+  );
+  await RedisApiUtil.setHash(
+    redisClient,
+    `${userInfo.userId}:${twilioPhoneNumber}`,
+    userInfo
+  );
+
   let messageHistoryContextText =
     'Below are our messages with the voter since they left this thread.';
   // If voter is new to a channel/thread, retrieve all message history. If a
@@ -497,25 +515,6 @@ const routeVoterToSlackChannelHelper = async (
       'ROUTER.routeVoterToSlackChannelHelper: Voter HAS been to this channel before.'
     );
   }
-
-  logger.debug(
-    "ROUTER.routeVoterToSlackChannelHelper: Changing voter's active channel."
-  );
-  // Reassign the active channel so that the next voter messages go to the
-  // new active channel.
-  userInfo.activeChannelId = destinationSlackChannelId;
-  userInfo.activeChannelName = destinationSlackChannelName;
-
-  // Update userInfo in Redis (remember state channel thread identifying info and new activeChannel).
-  logger.debug(
-    `ROUTER.routeVoterToSlackChannelHelper: Writing updated userInfo to Redis.`
-  );
-
-  await RedisApiUtil.setHash(
-    redisClient,
-    `${userInfo.userId}:${twilioPhoneNumber}`,
-    userInfo
-  );
 
   // Populate state channel thread with message history so far.
   await postUserMessageHistoryToSlack(
@@ -701,15 +700,6 @@ const routeVoterToSlackChannel = async (
     // Remember the voter's thread in this channel.
     userInfo[response.data.channel] = response.data.ts;
 
-    // Create the thread with the origin thread's need_attention status
-    await DbApiUtil.logThreadToDb({
-      slackParentMessageTs: response.data.ts,
-      channelId: response.data.channel,
-      userId: userInfo.userId,
-      userPhoneNumber: userInfo.userPhoneNumber,
-      needsAttention: needsAttention,
-    });
-
     // Be able to identify phone number using NEW Slack channel identifying info.
     await RedisApiUtil.setHash(
       redisClient,
@@ -730,6 +720,15 @@ const routeVoterToSlackChannel = async (
         destinationSlackParentMessageTs: response.data.ts,
       }
     );
+
+    // Create the thread with the origin thread's need_attention status
+    await DbApiUtil.logThreadToDb({
+      slackParentMessageTs: response.data.ts,
+      channelId: response.data.channel,
+      userId: userInfo.userId,
+      userPhoneNumber: userInfo.userPhoneNumber,
+      needsAttention: needsAttention,
+    });
 
     return;
   }


### PR DESCRIPTION
Currently, a number of operations execute between a) the time a new thread is created in a new Slack channel to which a voter is being routed, and b) the time that Redis is updated to reflect the voter's new thread and channel:

1. A new row is logged to the DB threads table
2. The message history is posted in the new thread.

In this time, the voter might message again, and if Redis does not reflect the new channel, the voter's message might trigger another re-routing of the voter.

We saw this happen twice today (the voter texted two consecutive texts within 1-2 seconds).

This PR moves the Redis update happen before the two operations listed above, so that the chance increases that the voter's subsequent message will successfully be sent to the new channel/thread.