### PR TITLE
Format Twilio attachments as block 

### DIFF
--- a/sql/20201027-twilio-attachments.sql
+++ b/sql/20201027-twilio-attachments.sql
@@ -1,0 +1,5 @@
+-- Store the array of slack_attachments as a jsonb column. We use jsonb rather than
+-- a text array because they have similar performance, but JSON is easier to
+-- sync to a Redshift data warehouse (e.g. Civis)
+ALTER TABLE messages
+ADD COLUMN twilio_attachments jsonb;

--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -158,7 +158,7 @@ export async function logMessageToDb(
         databaseMessageEntry.archived,
         databaseMessageEntry.stateName,
 
-        // We can't just pass these arrays as-is because this are JSON columns,
+        // We can't just pass these arrays as-is because these are JSON columns,
         // and node-pg serializes arrays as PG arrays rather than JSON arrays.
         databaseMessageEntry.slackFiles
           ? JSON.stringify(databaseMessageEntry.slackFiles)

--- a/src/router.test.js
+++ b/src/router.test.js
@@ -74,10 +74,15 @@ const expectNthSlackMessageToChannel = (
       channelMessageNum++;
       if (channelMessageNum == n) {
         const slackMessage = SlackApiUtil.sendMessage.mock.calls[i][0];
+        const slackOpts = SlackApiUtil.sendMessage.mock.calls[i][1];
         for (let j = 0; j < messageParts.length; j++) {
-          expect(slackMessage).toEqual(
-            expect.stringContaining(messageParts[j])
-          );
+          if (typeof messageParts[j] === 'string') {
+            expect(slackMessage).toEqual(
+              expect.stringContaining(messageParts[j])
+            );
+          } else {
+            expect(slackOpts).toEqual(expect.objectContaining(messageParts[j]));
+          }
         }
         if (parentMessageTs) {
           expect(slackMessageParams).toEqual(
@@ -179,8 +184,16 @@ describe('handleNewVoter', () => {
   });
 
   test('Relays voter message in subsequent message to Slack', () => {
-    expect(SlackApiUtil.sendMessage.mock.calls[1][0]).toEqual(
-      expect.stringContaining('can you help me vote')
+    expect(SlackApiUtil.sendMessage.mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        blocks: [
+          expect.objectContaining({
+            text: expect.objectContaining({
+              text: 'can you help me vote',
+            }),
+          }),
+        ],
+      })
     );
     expect(SlackApiUtil.sendMessage.mock.calls[1][1]).toEqual(
       expect.objectContaining({
@@ -471,8 +484,16 @@ describe('determineVoterState', () => {
       );
     });
     test('Passes voter message to Slack', () => {
-      expect(SlackApiUtil.sendMessage.mock.calls[0][0]).toContain(
-        'nonsensical statement'
+      expect(SlackApiUtil.sendMessage.mock.calls[0][1]).toEqual(
+        expect.objectContaining({
+          blocks: [
+            expect.objectContaining({
+              text: expect.objectContaining({
+                text: 'nonsensical statement',
+              }),
+            }),
+          ],
+        })
       );
     });
 
@@ -782,7 +803,17 @@ describe('determineVoterState', () => {
         expectNthSlackMessageToChannel(
           'CTHELOBBYID',
           0,
-          ['NC'],
+          [
+            {
+              blocks: [
+                expect.objectContaining({
+                  text: expect.objectContaining({
+                    text: 'NC',
+                  }),
+                }),
+              ],
+            },
+          ],
           '293874928374'
         );
       });
@@ -1145,11 +1176,15 @@ describe('handleDisclaimer', () => {
     });
 
     test('Passes voter message to Slack lobby channel', () => {
-      expect(SlackApiUtil.sendMessage.mock.calls[0][0]).toContain(
-        'response to state question'
-      );
       expect(SlackApiUtil.sendMessage.mock.calls[0][1]).toEqual(
         expect.objectContaining({
+          blocks: [
+            expect.objectContaining({
+              text: expect.objectContaining({
+                text: 'response to state question',
+              }),
+            }),
+          ],
           parentMessageTs: '293874928374',
           channel: 'CTHELOBBYID',
         })
@@ -1478,8 +1513,16 @@ describe('handleClearedVoter', () => {
       twilioPhoneNumber,
       inboundDbMessageEntry
     ).then(() => {
-      expect(SlackApiUtil.sendMessage.mock.calls[0][0]).toContain(
-        'subsequent message'
+      expect(SlackApiUtil.sendMessage.mock.calls[0][1]).toEqual(
+        expect.objectContaining({
+          blocks: [
+            expect.objectContaining({
+              text: expect.objectContaining({
+                text: 'subsequent message',
+              }),
+            }),
+          ],
+        })
       );
     });
   });

--- a/src/slack_block_util.ts
+++ b/src/slack_block_util.ts
@@ -458,6 +458,48 @@ export function replaceVoterPanelBlocks(
   return newBlocks;
 }
 
+export function formatMessageWithAttachmentLinks(
+  text: string,
+  links: string[] = []
+): SlackBlock[] {
+  const ret: SlackBlock[] = [];
+  if (text) {
+    ret.push({
+      type: 'section',
+      text: {
+        // SMS-inputted text, don't apply Slack formatting
+        type: 'plain_text',
+        text,
+        emoji: false,
+      },
+    });
+  }
+
+  // Format links as a set of buttons
+  let currentActionBlock: SlackBlock | undefined;
+  links?.forEach((link, i) => {
+    // Max 5 buttons per actions block
+    if (!currentActionBlock || currentActionBlock.elements?.length >= 5) {
+      currentActionBlock = {
+        type: 'actions',
+        elements: [],
+      };
+      ret.push(currentActionBlock);
+    }
+    currentActionBlock.elements.push({
+      type: 'button',
+      text: {
+        type: 'plain_text',
+        text: `:paperclip: Attachment ${i + 1}`,
+        emoji: true,
+      },
+      url: link,
+    });
+  });
+
+  return ret;
+}
+
 // This function finds the element for a given action ID in a set of blocks
 export function findElementWithActionId(
   blocks: SlackBlock[],

--- a/src/slack_message_formatter.ts
+++ b/src/slack_message_formatter.ts
@@ -1,11 +1,24 @@
 import { HistoricalMessage } from './types';
 import logger from './logger';
 
-const formatMessageBlock = (msg: string, formatchar: string) => {
+const formatMessageBlock = (
+  msg: string,
+  attachments: string[] | null | undefined,
+  formatchar: string
+) => {
   return msg
     .split('\n')
     .map((x) => (x ? formatchar + x + formatchar : x))
     .map((x) => '>' + x)
+    .concat(
+      attachments?.length
+        ? [
+            `*Attachments:* ${attachments
+              .map((url, i) => `<${url}|Attachment ${i + 1}>`)
+              .join(' ')}`,
+          ]
+        : []
+    )
     .join('\n');
 };
 
@@ -23,21 +36,29 @@ export function formatMessageHistory(
         `:bust_in_silhouette: *Voter ${userId}*  ` +
         specialSlackTimestamp +
         '\n' +
-        formatMessageBlock(messageObject.message, '*')
+        formatMessageBlock(
+          messageObject.message,
+          messageObject.twilio_attachments,
+          '*'
+        )
       );
     } else if (messageObject.automated) {
       return (
         ':gear: *Helpline (Automated)*  ' +
         specialSlackTimestamp +
         '\n' +
-        formatMessageBlock(messageObject.message, '_')
+        formatMessageBlock(messageObject.message, [], '_')
       );
     } else {
       return (
         `:adult: *${messageObject.originating_slack_user_name} (Volunteer)*  ` +
         specialSlackTimestamp +
         '\n' +
-        formatMessageBlock(messageObject.message, '')
+        formatMessageBlock(
+          messageObject.message,
+          messageObject.slack_attachments?.map(({ permalink }) => permalink),
+          ''
+        )
       );
     }
   });

--- a/src/twilio_util.ts
+++ b/src/twilio_util.ts
@@ -37,25 +37,23 @@ export type TwilioRequestBody = {
   [mediaKey: string]: string | undefined;
 };
 
-export function formatAttachments(reqBody: TwilioRequestBody): string {
+/** Returns list of URLs for MMS attachments */
+export function getAttachments(reqBody: TwilioRequestBody): string[] {
   const numMedia = Number(reqBody.NumMedia);
 
   if (numMedia === 0) {
     // no media to handle
-    return reqBody.Body;
+    return [];
   }
 
-  const mediaURLs = [];
+  const mediaURLs: string[] = [];
   for (let i = 0; i < numMedia; i++) {
     const mediaKey = `MediaUrl${i}`;
-    if (reqBody[mediaKey]) {
-      mediaURLs.push(reqBody[mediaKey]);
+    const url = reqBody[mediaKey];
+    if (url) {
+      mediaURLs.push(url);
     }
   }
 
-  const mediaURLsFormatted = mediaURLs
-    .map((url, i) => `<${url}|Attachment ${i + 1}>`)
-    .join(' ');
-
-  return `${reqBody.Body}\n[Attachments: ${mediaURLsFormatted}]`;
+  return mediaURLs;
 }

--- a/src/twilio_util.ts
+++ b/src/twilio_util.ts
@@ -37,15 +37,14 @@ export type TwilioRequestBody = {
   [mediaKey: string]: string | undefined;
 };
 
-/** Returns list of URLs for MMS attachments */
+// Returns list of URLs for MMS attachments
 export function getAttachments(reqBody: TwilioRequestBody): string[] {
-  const numMedia = Number(reqBody.NumMedia);
-
-  if (numMedia === 0) {
+  if (reqBody.NumMedia === '0') {
     // no media to handle
     return [];
   }
 
+  const numMedia = Number(reqBody.NumMedia);
   const mediaURLs: string[] = [];
   for (let i = 0; i < numMedia; i++) {
     const mediaKey = `MediaUrl${i}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,8 @@ export type HistoricalMessage = {
   automated: boolean;
   direction: MessageDirection;
   originating_slack_user_name: string;
+  slack_attachments: { id: string; permalink: string }[] | null;
+  twilio_attachments: string[] | null;
 };
 
 export type SlackThreadInfo = {


### PR DESCRIPTION
This switches incoming Twilio messages to blocks instead of standard Mrkdwn text, and displays any media attachments as Slack button blocks to distinguish them from possibly unsafe links.

<img width="460" alt="Screen Shot 2020-10-27 at 11 27 33 PM" src="https://user-images.githubusercontent.com/179327/97409920-9f919000-18bb-11eb-9cf3-81b728bca347.png">

It requires altering the DB with a new JSON column with the media links since we're now storing those as its own data rather than just extra text appended to the message.