### PR TITLE
Revamp needs-attention handling

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -196,6 +196,7 @@ export async function handleKnownVoterBlockLogic(
           parentMessageTs: userInfo[userInfo.activeChannelId],
           channel: userInfo.activeChannelId,
           isVoterMessage: true,
+          isBlocked: true,
         },
         inboundDbMessageEntry,
         userInfo

--- a/src/slack_api_util.ts
+++ b/src/slack_api_util.ts
@@ -40,6 +40,7 @@ type SlackSendMessageOptions = {
   blocks?: SlackBlock[];
   isVoterMessage?: boolean;
   isAutomatedMessage?: boolean;
+  isBlocked?: boolean;
 };
 
 type SlackChannelNamesAndIds = {
@@ -239,7 +240,9 @@ export async function sendMessage(
 
       try {
         await DbApiUtil.logMessageToDb(databaseMessageEntry);
-        await DbApiUtil.updateThreadStatusFromMessage(databaseMessageEntry);
+        if (!options.isBlocked) {
+          await DbApiUtil.updateThreadStatusFromMessage(databaseMessageEntry);
+        }
       } catch (error) {
         logger.info(
           `SLACKAPIUTIL.sendMessage: failed to log message send success to DB`

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -248,6 +248,11 @@ export async function handleVoterStatusUpdate({
             { [userPhoneNumber]: '1' }
           );
         }
+        await DbApiUtil.setThreadNeedsAttentionToDb(
+          payload.container.thread_ts,
+          payload.channel.id,
+          false
+        );
       }
       // Steps to take if the dropdown was changed.
     } else {


### PR DESCRIPTION
This changes the way we update needs-attention:

- Needs attention no longer depends on whether a volunteer is assigned.
- Needs attention is set on a new thread, and when an incoming message is handled from a cleared voter (i.e., past lobby, or volunteer engaged)
- Needs attention is cleared when a slack thread message is relayed to the voter (i.e., not a command)

Implementation notes:
- We pull the updates out of the twilio/slack send functions, which are deep in the call chain and kludgey.  Instead, we update from high level methods.
- The thread ``updated_at`` field is now updated from ``logMessageToDb``.
- The old method that updates from the databaseMessageEntry is gone; instead the callers explicitly set true or false for the thread.

This is simpler and easier to understand.  The main net change from a volunteer perspective is that if you start talking to a voter that is unclaimed their needs-attention status will get cleared.  However, they will still be unclaimed, so I don't think they will get lost.