### PR TITLE
fix broadcast bad usage error message (and make it ephemeral)

### DIFF
--- a/external_config/slack.md
+++ b/external_config/slack.md
@@ -193,6 +193,7 @@ This should be added as a **global** shortcut.
 - **Request URL:** base URL + /slack-command
 - **Short Description:** List unclaimed voters in a channel
 - **Usage Hint:** (None)
+- **Escape channels, users, and links sent to your app:** Unchecked
 
 #### Needs attention
 
@@ -200,6 +201,7 @@ This should be added as a **global** shortcut.
 - **Request URL:** base URL + /slack-command
 - **Short Description:** List voters needing your attention
 - **Usage Hint:** (None)
+- **Escape channels, users, and links sent to your app:** Checked
 
 #### Broadcast
 
@@ -207,6 +209,7 @@ This should be added as a **global** shortcut.
 - **Request URL:** base URL + /slack-command
 - **Short Description:** Broadcast helpline status to channels or volunteers
 - **Usage Hint:** channel-status|volunteer-status [optional preamble message]
+- **Escape channels, users, and links sent to your app:** Unchecked
 
 #### Follow-up
 
@@ -214,3 +217,4 @@ This should be added as a **global** shortcut.
 - **Request URL:** base URL + /slack-command
 - **Short Description:** List voters to follow-up with
 - **Usage Hint:** days-idle
+- **Escape channels, users, and links sent to your app:** Unchecked

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -464,9 +464,10 @@ export async function handleCommandUnclaimed(
       arg = arg.substr(1); // strip off the # prefix
     }
     if (!(arg in slackChannelIds)) {
-      await SlackApiUtil.sendMessage(`Channel #${arg} not found`, {
-        channel: channelId,
-      });
+      await SlackApiUtil.sendEphemeralResponse(
+        responseUrl,
+        `Channel #${arg} not found`
+      );
       return;
     }
     showChannelName = arg;


### PR DESCRIPTION
The old error path was just broken.. it was posting a permanent message to the wrong channel (we want all responses to this command to be ephemeral). Also the prod deployment was misconfigured; update the docs to reflect the escaping option for slash commands!