### PR TITLE
Handle VOTED in more places

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import morgan from 'morgan';
 import axios, { AxiosResponse } from 'axios';
 import { Pool } from 'pg';
 
+import * as MessageConstants from './message_constants';
 import * as SlackApiUtil from './slack_api_util';
 import * as SlackInteractionHandler from './slack_interaction_handler';
 import * as TwilioApiUtil from './twilio_api_util';
@@ -29,6 +30,8 @@ import { handleTwilioStatusCallback } from './twilio_status_callback_handler';
 import { SlackInteractionEventPayload } from './slack_interaction_handler';
 import { TwilioRequestBody } from './twilio_util';
 import * as KeywordParser from './keyword_parser';
+import { SlackActionId } from './slack_interaction_ids';
+import { VoterStatus } from './types';
 
 const app = express();
 
@@ -356,6 +359,58 @@ const handleIncomingTwilioMessage = async (
       logger.info(
         `SERVER.handleIncomingTwilioMessage (${userId}): Voter has previously confirmed the disclaimer, or one is not required for this organization.`
       );
+
+      // always update the status if user texts VOTED
+      if (KeywordParser.isVotedKeyword(userMessage)) {
+        // log it
+        await DbApiUtil.logVoterStatusToDb({
+          userId: userInfo.userId,
+          userPhoneNumber: userInfo.userPhoneNumber,
+          twilioPhoneNumber: twilioPhoneNumber,
+          isDemo: userInfo.isDemo,
+          voterStatus: 'VOTED',
+          originatingSlackUserName: null,
+          originatingSlackUserId: null,
+          slackChannelName: null,
+          slackChannelId: null,
+          slackParentMessageTs: null,
+          actionTs: null,
+        });
+        await SlackApiUtil.sendMessage(
+          `*Operator:* Voter status changed to *VOTED* by user text.`,
+          {
+            channel: userInfo.activeChannelId,
+            parentMessageTs: userInfo[userInfo.activeChannelId],
+          }
+        );
+
+        // update blocks
+        const blocks = await SlackApiUtil.fetchSlackMessageBlocks(
+          userInfo.activeChannelId,
+          userInfo[userInfo.activeChannelId]
+        );
+        if (blocks) {
+          if (
+            !SlackBlockUtil.populateDropdownNewInitialValue(
+              blocks,
+              SlackActionId.VOTER_STATUS_DROPDOWN,
+              'VOTED' as VoterStatus
+            )
+          ) {
+            logger.error(
+              'ROUTER.handleClearedVoter: unable to modify status dropdown'
+            );
+          }
+          await SlackInteractionApiUtil.updateVoterStatusBlocks(
+            userInfo.activeChannelId,
+            userInfo[userInfo.activeChannelId],
+            blocks
+          );
+        } else {
+          logger.error('ROUTER.handleClearedVoter: unable to fetch old blocks');
+        }
+      }
+
       // Voter has a state determined. The U.S. state name is used for
       // operator messages as well as to know whether a U.S. state is known
       // for the voter. This may not be ideal (create separate bool?).
@@ -378,6 +433,33 @@ const handleIncomingTwilioMessage = async (
           inboundDbMessageEntry,
           twilioCallbackURL
         );
+        // Voter texted VOTED during the state determination
+      } else if (KeywordParser.isVotedKeyword(userMessage)) {
+        await SlackApiUtil.sendMessage(
+          userMessage,
+          {
+            parentMessageTs: userInfo[userInfo.activeChannelId],
+            channel: userInfo.activeChannelId,
+            isVoterMessage: true,
+          },
+          inboundDbMessageEntry,
+          userInfo
+        );
+        const replyMessage = MessageConstants.VOTED_RESPONSE();
+        await TwilioApiUtil.sendMessage(
+          replyMessage,
+          {
+            userPhoneNumber: userPhoneNumber,
+            twilioPhoneNumber,
+            twilioCallbackURL,
+          },
+          DbApiUtil.populateAutomatedDbMessageEntry(userInfo)
+        );
+        await SlackApiUtil.sendMessage(replyMessage, {
+          parentMessageTs: userInfo[userInfo.activeChannelId],
+          channel: userInfo.activeChannelId,
+          isAutomatedMessage: true,
+        });
         // Voter has no state determined
       } else {
         logger.info(

--- a/src/app.ts
+++ b/src/app.ts
@@ -359,7 +359,10 @@ const handleIncomingTwilioMessage = async (
 
       // Always update the status if user texts VOTED, regardless of what mode
       // we are in below.
-      if (KeywordParser.isVotedKeyword(userMessage)) {
+      if (
+        process.env.CLIENT_ORGANIZATION === 'VOTE_AMERICA' &&
+        KeywordParser.isVotedKeyword(userMessage)
+      ) {
         await Router.recordVotedStatus(userInfo, twilioPhoneNumber);
       }
 
@@ -386,7 +389,10 @@ const handleIncomingTwilioMessage = async (
           twilioCallbackURL
         );
         // Voter texted VOTED during the state determination
-      } else if (KeywordParser.isVotedKeyword(userMessage)) {
+      } else if (
+        process.env.CLIENT_ORGANIZATION === 'VOTE_AMERICA' &&
+        KeywordParser.isVotedKeyword(userMessage)
+      ) {
         await Router.replyToVoted(
           userInfo,
           twilioPhoneNumber,

--- a/src/message_constants.ts
+++ b/src/message_constants.ts
@@ -83,6 +83,10 @@ export function VOTED_WELCOME_RESPONSE(): string {
   return 'Thank you for voting! Please remind your friends and family to vote too.\n\nReply HELPLINE if you have any questions, or STOP to opt out of texts. Msg&data rates may apply.';
 }
 
+export function VOTED_RESPONSE(): string {
+  return 'Thank you for voting!';
+}
+
 export function STATE_QUESTION(): string {
   switch (process.env.CLIENT_ORGANIZATION) {
     case 'VOTE_AMERICA':

--- a/src/router.ts
+++ b/src/router.ts
@@ -19,7 +19,6 @@ import * as Sentry from '@sentry/node';
 import { isVotedKeyword } from './keyword_parser';
 import { SlackActionId } from './slack_interaction_ids';
 import { SlackFile } from './message_parser';
-import { VoterStatus } from './types';
 
 const MINS_BEFORE_WELCOME_BACK_MESSAGE = 60 * 24;
 export const NUM_STATE_SELECTION_ATTEMPTS_LIMIT = 2;
@@ -1257,56 +1256,6 @@ export async function handleClearedVoter(
       nowSecondsEpoch - lastVoterMessageSecsFromEpoch
     }`
   );
-
-  if (isVotedKeyword(userOptions.userMessage)) {
-    // log it
-    await DbApiUtil.logVoterStatusToDb({
-      userId: userInfo.userId,
-      userPhoneNumber: userInfo.userPhoneNumber,
-      twilioPhoneNumber: twilioPhoneNumber,
-      isDemo: userInfo.isDemo,
-      voterStatus: 'VOTED',
-      originatingSlackUserName: null,
-      originatingSlackUserId: null,
-      slackChannelName: null,
-      slackChannelId: null,
-      slackParentMessageTs: null,
-      actionTs: null,
-    });
-    await SlackApiUtil.sendMessage(
-      `*Operator:* Voter status changed to *VOTED* by user text.`,
-      {
-        channel: userInfo.activeChannelId,
-        parentMessageTs: userInfo[userInfo.activeChannelId],
-      }
-    );
-
-    // update blocks
-    let blocks = await SlackApiUtil.fetchSlackMessageBlocks(
-      userInfo.activeChannelId,
-      userInfo[userInfo.activeChannelId]
-    );
-    if (blocks) {
-      if (
-        !SlackBlockUtil.populateDropdownNewInitialValue(
-          blocks,
-          SlackActionId.VOTER_STATUS_DROPDOWN,
-          'VOTED' as VoterStatus
-        )
-      ) {
-        logger.error(
-          'ROUTER.handleClearedVoter: unable to modify status dropdown'
-        );
-      }
-      await SlackInteractionApiUtil.updateVoterStatusBlocks(
-        userInfo.activeChannelId,
-        userInfo[userInfo.activeChannelId],
-        blocks
-      );
-    } else {
-      logger.error('ROUTER.handleClearedVoter: unable to fetch old blocks');
-    }
-  }
 
   if (
     nowSecondsEpoch - lastVoterMessageSecsFromEpoch >

--- a/src/router.ts
+++ b/src/router.ts
@@ -13,7 +13,7 @@ import * as CommandUtil from './command_util';
 import * as MessageParser from './message_parser';
 import * as SlackInteractionApiUtil from './slack_interaction_api_util';
 import logger from './logger';
-import { EntryPoint, UserInfo } from './types';
+import { EntryPoint, UserInfo, VoterStatus } from './types';
 import { PromisifiedRedisClient } from './redis_client';
 import * as Sentry from '@sentry/node';
 import { isVotedKeyword } from './keyword_parser';
@@ -914,6 +914,94 @@ const routeVoterToSlackChannel = async (
 
   await DbApiUtil.setThreadInactive(oldSlackParentMessageTs, oldChannelId);
 };
+
+export async function recordVotedStatus(
+  userInfo: UserInfo,
+  twilioPhoneNumber: string
+): Promise<void> {
+  // Log the VOTED status
+  await DbApiUtil.logVoterStatusToDb({
+    userId: userInfo.userId,
+    userPhoneNumber: userInfo.userPhoneNumber,
+    twilioPhoneNumber: twilioPhoneNumber,
+    isDemo: userInfo.isDemo,
+    voterStatus: 'VOTED',
+    originatingSlackUserName: null,
+    originatingSlackUserId: null,
+    slackChannelName: null,
+    slackChannelId: null,
+    slackParentMessageTs: null,
+    actionTs: null,
+  });
+  await SlackApiUtil.sendMessage(
+    `*Operator:* Voter status changed to *VOTED* by user text.`,
+    {
+      channel: userInfo.activeChannelId,
+      parentMessageTs: userInfo[userInfo.activeChannelId],
+    }
+  );
+
+  // Update voter status blocks
+  const blocks = await SlackApiUtil.fetchSlackMessageBlocks(
+    userInfo.activeChannelId,
+    userInfo[userInfo.activeChannelId]
+  );
+  if (blocks) {
+    if (
+      !SlackBlockUtil.populateDropdownNewInitialValue(
+        blocks,
+        SlackActionId.VOTER_STATUS_DROPDOWN,
+        'VOTED' as VoterStatus
+      )
+    ) {
+      logger.error(
+        'ROUTER.handleClearedVoter: unable to modify status dropdown'
+      );
+    }
+    await SlackInteractionApiUtil.updateVoterStatusBlocks(
+      userInfo.activeChannelId,
+      userInfo[userInfo.activeChannelId],
+      blocks
+    );
+  } else {
+    logger.error('ROUTER.handleClearedVoter: unable to fetch old blocks');
+  }
+}
+
+export async function replyToVoted(
+  userInfo: UserInfo,
+  twilioPhoneNumber: string,
+  twilioCallbackURL: string,
+  userMessage: string,
+  inboundDbMessageEntry: DbApiUtil.DatabaseMessageEntry
+): Promise<void> {
+  // record the incoming user message
+  await SlackApiUtil.sendMessage(
+    userMessage,
+    {
+      parentMessageTs: userInfo[userInfo.activeChannelId],
+      channel: userInfo.activeChannelId,
+      isVoterMessage: true,
+    },
+    inboundDbMessageEntry,
+    userInfo
+  );
+  const replyMessage = MessageConstants.VOTED_RESPONSE();
+  await TwilioApiUtil.sendMessage(
+    replyMessage,
+    {
+      userPhoneNumber: userInfo.userPhoneNumber,
+      twilioPhoneNumber,
+      twilioCallbackURL,
+    },
+    DbApiUtil.populateAutomatedDbMessageEntry(userInfo)
+  );
+  await SlackApiUtil.sendMessage(replyMessage, {
+    parentMessageTs: userInfo[userInfo.activeChannelId],
+    channel: userInfo.activeChannelId,
+    isAutomatedMessage: true,
+  });
+}
 
 export async function determineVoterState(
   userOptions: UserOptions & { userInfo: UserInfo },

--- a/src/slack_interaction_api_util.ts
+++ b/src/slack_interaction_api_util.ts
@@ -58,6 +58,25 @@ export function addBackVoterStatusPanel({
   });
 }
 
+export async function updateVoterStatusBlocks(
+  channelId: string,
+  parentMessageTs: string,
+  blocks: SlackBlock[]
+): Promise<void> {
+  // HACK: work around slack bug updating blocks: we need to update the block_id
+  blocks[2].block_id = Math.random()
+    .toString(36)
+    .replace(/[^a-z]+/g, '')
+    .substr(0, 8);
+
+  // Replace the entire block so that the initial option change persists.
+  await replaceSlackMessageBlocks({
+    slackChannelId: channelId,
+    slackParentMessageTs: parentMessageTs,
+    newBlocks: blocks,
+  });
+}
+
 // This function is used in app.js for automated refusals.
 export async function handleAutomatedCollapseOfVoterStatusPanel({
   userInfo,

--- a/src/slack_interaction_handler.test.js
+++ b/src/slack_interaction_handler.test.js
@@ -97,7 +97,7 @@ describe('SlackInteractionHandler', () => {
                 }),
               ]),
             }),
-          ]),
+          ])
         );
       }
     );

--- a/src/slack_interaction_handler.test.js
+++ b/src/slack_interaction_handler.test.js
@@ -11,11 +11,11 @@ import logger from './logger';
 
 describe('SlackInteractionHandler', () => {
   describe('handleVoterStatusUpdate', () => {
-    let error, replaceSlackMessageBlocks, sendMessage, logVoterStatusToDb;
+    let error, updateVoterStatusBlocks, sendMessage, logVoterStatusToDb;
     beforeEach(() => {
       error = jest.spyOn(logger, 'error');
-      replaceSlackMessageBlocks = jest
-        .spyOn(SlackInteractionApiUtil, 'replaceSlackMessageBlocks')
+      updateVoterStatusBlocks = jest
+        .spyOn(SlackInteractionApiUtil, 'updateVoterStatusBlocks')
         .mockImplementation(() => {});
       sendMessage = jest
         .spyOn(SlackApiUtil, 'sendMessage')
@@ -79,10 +79,10 @@ describe('SlackInteractionHandler', () => {
             slackParentMessageTs: expect.any(String),
           })
         );
-        expect(replaceSlackMessageBlocks).toHaveBeenCalledWith({
-          slackChannelId: expect.any(String),
-          slackParentMessageTs: expect.any(String),
-          newBlocks: expect.arrayContaining([
+        expect(updateVoterStatusBlocks).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(String),
+          expect.arrayContaining([
             expect.objectContaining({
               type: 'actions',
               elements: expect.arrayContaining([
@@ -98,7 +98,7 @@ describe('SlackInteractionHandler', () => {
               ]),
             }),
           ]),
-        });
+        );
       }
     );
   });

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -260,7 +260,7 @@ export async function handleVoterStatusUpdate({
         );
       }
 
-      // Update the voter block
+      // Replace the entire block so that the initial option change persists.
       await SlackInteractionApiUtil.updateVoterStatusBlocks(
         payload.channel.id,
         payload.container.thread_ts,

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -260,7 +260,7 @@ export async function handleVoterStatusUpdate({
         );
       }
 
-      // Replace the entire block so that the initial option change persists.
+      // Update voter panel
       await SlackInteractionApiUtil.updateVoterStatusBlocks(
         payload.channel.id,
         payload.container.thread_ts,

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -260,18 +260,12 @@ export async function handleVoterStatusUpdate({
         );
       }
 
-      // HACK: work around slack bug updating blocks by adjusting the block_id
-      payload.message.blocks[2]['block_id'] = Math.random()
-        .toString(36)
-        .replace(/[^a-z]+/g, '')
-        .substr(0, 8);
-
-      // Replace the entire block so that the initial option change persists.
-      await SlackInteractionApiUtil.replaceSlackMessageBlocks({
-        slackChannelId: payload.channel.id,
-        slackParentMessageTs: payload.container.thread_ts,
-        newBlocks: payload.message.blocks,
-      });
+      // Update the voter block
+      await SlackInteractionApiUtil.updateVoterStatusBlocks(
+        payload.channel.id,
+        payload.container.thread_ts,
+        payload.message.blocks
+      );
     }
   } else if (
     selectedVoterStatus === 'UNDO' &&


### PR DESCRIPTION
- If the user texts VOTED, we always update the voter status
- We continue to autoreply before HELPLINE (as before)
- New: autoreply if we are in the lobby before the voter has intervened
- New: autoreply if we would have sent a "Welcome back! Finding a volunteer..." message

This is based on top of #205 
This was already tested in staging