### PR TITLE
Session topics

### DIFF
--- a/sql/20201116-voter-topics.sql
+++ b/sql/20201116-voter-topics.sql
@@ -1,0 +1,13 @@
+--- record voter topic selections
+
+CREATE TABLE session_topics (
+  created_at TIMESTAMPTZ NOT NULL,
+  user_id TEXT NOT NULL,
+  user_phone_number TEXT NOT NULL,
+  twilio_phone_number TEXT NOT NULL,
+  session_start_at TIMESTAMPTZ NOT NULL,
+  is_demo BOOLEAN,
+  archived BOOLEAN,
+  topics JSONB,
+  PRIMARY KEY (created_at, user_id, twilio_phone_number, session_start_at)
+);

--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -370,6 +370,16 @@ async function slackInteractivityHandler(
         userPhoneNumber: redisData ? redisData.userPhoneNumber : null,
         twilioPhoneNumber: redisData ? redisData.twilioPhoneNumber : null,
       });
+    } else if (payload.actions[0].action_id === SlackActionId.SESSION_TOPICS) {
+      logger.info(
+        `SERVER POST /slack-interactivity: Determined user interaction is a session topics update.`
+      );
+      const MD5 = new Hashes.MD5();
+      await SlackInteractionHandler.handleSessionTopicUpdate({
+        payload: payload,
+        userId: MD5.hex(redisData.userPhoneNumber),
+        twilioPhoneNumber: redisData.twilioPhoneNumber,
+      });
     } else {
       throw Error(`Unrecognized action_id ${payload.actions[0].action_id}`);
     }

--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -599,6 +599,15 @@ export async function archiveDemoVoter(
         AND twilio_phone_number = $2`,
       [userId, twilioPhoneNumber]
     );
+    await client.query(
+      `UPDATE session_topics
+      SET archived = true
+      WHERE
+        is_demo = true
+        AND user_id = $1
+        AND twilio_phone_number = $2`,
+      [userId, twilioPhoneNumber]
+    );
     logger.info(
       `DBAPIUTIL.archiveDemoVoter: Successfully archived demo voter.`
     );

--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -1563,3 +1563,29 @@ export async function logCommandToDb(
     client.release();
   }
 }
+
+export async function logSessionTopicsToDb(
+  userInfo: UserInfo,
+  twilioPhoneNumber: string,
+  topics: string[]
+): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query(
+      'INSERT INTO session_topics (created_at, user_id, user_phone_number, twilio_phone_number, session_start_at, is_demo, archived, topics) VALUES (now(), $1, $2, $3, TO_TIMESTAMP($4), $5, false, $6)',
+      [
+        userInfo.userId,
+        userInfo.userPhoneNumber,
+        twilioPhoneNumber,
+        userInfo.sessionStartEpoch,
+        userInfo.isDemo,
+        JSON.stringify(topics),
+      ]
+    );
+    logger.info(
+      `DBAPIUTIL.logTopicsToDb: Successfully stored topics in database.`
+    );
+  } finally {
+    client.release();
+  }
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1669,32 +1669,35 @@ export async function handleSlackThreadCommand(
       userInfo.activeChannelId,
       userInfo[userInfo.activeChannelId]
     );
-    const operatorMessage = voterHeader(userInfo, false);
-    const freshBlocks = SlackBlockUtil.getVoterStatusBlocks(operatorMessage);
-    let newBlocks;
-    if (oldBlocks) {
-      newBlocks = SlackBlockUtil.replaceVoterPanelBlocks(oldBlocks, [
-        freshBlocks[2],
-      ]);
-    } else {
-      newBlocks = freshBlocks;
+    if (!oldBlocks) {
+      await SlackApiUtil.sendMessage('*Operator:* Unable to fetch old blocks', {
+        parentMessageTs: reqBody.event.thread_ts,
+        channel: reqBody.event.channel,
+      });
+      await SlackApiUtil.addSlackMessageReaction(
+        reqBody.event.channel,
+        reqBody.event.ts,
+        'x'
+      );
+      return true;
     }
-    const status = await DbApiUtil.getLatestVoterStatus(
+    const status = ((await DbApiUtil.getLatestVoterStatus(
       userInfo.userId,
       twilioPhoneNumber
-    );
-    if (status !== 'UNKNOWN') {
-      SlackBlockUtil.populateDropdownNewInitialValue(
-        newBlocks,
-        SlackActionId.VOTER_STATUS_DROPDOWN,
-        status
-      );
-    }
-    await SlackInteractionApiUtil.replaceSlackMessageBlocks({
+    )) || 'UNKNOWN') as VoterStatus;
+    const topics =
+      (await DbApiUtil.getThreadTopics(
+        reqBody.event.channel,
+        reqBody.event.ts
+      )) || [];
+    await SlackInteractionApiUtil.addBackVoterStatusPanel({
       slackChannelId: userInfo.activeChannelId,
       slackParentMessageTs: userInfo[userInfo.activeChannelId],
-      newBlocks: newBlocks,
+      oldBlocks: oldBlocks,
+      status: status,
+      topics: topics,
     });
+
     await RedisApiUtil.setHash(
       redisClient,
       `${userInfo.userId}:${twilioPhoneNumber}`,

--- a/src/slack_block_util.ts
+++ b/src/slack_block_util.ts
@@ -1,6 +1,6 @@
 import logger from './logger';
 import { SlackActionId } from './slack_interaction_ids';
-import type { VoterStatus } from './types';
+import { SessionTopics, VoterStatus } from './types';
 import { SlackModalPrivateMetadata } from './slack_interaction_handler';
 import { cloneDeep } from 'lodash';
 
@@ -273,6 +273,32 @@ export const voterStatusPanel: SlackBlock = {
   ],
 };
 
+export const voterTopicPanel: SlackBlock = {
+  type: 'section',
+  block_id: 'votertopic',
+  text: {
+    type: 'mrkdwn',
+    text: 'Voter questions, topics discussed',
+  },
+  accessory: {
+    action_id: SlackActionId.SESSION_TOPICS,
+    type: 'multi_static_select',
+    placeholder: {
+      type: 'plain_text',
+      text: 'Select',
+    },
+    options: Object.entries(SessionTopics).map(([k, v]) => {
+      return {
+        text: {
+          type: 'plain_text',
+          text: v,
+        },
+        value: k,
+      };
+    }),
+  },
+};
+
 export function loadingSlackView(): SlackView {
   return {
     title: {
@@ -349,6 +375,7 @@ export function getVoterStatusBlocks(messageText: string): SlackBlock[] {
     voterInfoSection(messageText),
     volunteerSelectionPanel,
     voterStatusPanel,
+    voterTopicPanel,
   ]);
 }
 

--- a/src/slack_interaction_api_util.ts
+++ b/src/slack_interaction_api_util.ts
@@ -4,12 +4,13 @@ import {
   SlackBlock,
 } from './slack_block_util';
 import logger from './logger';
-import { UserInfo, SessionTopics } from './types';
+import { UserInfo, SessionTopics, VoterStatus } from './types';
 import * as SlackApiUtil from './slack_api_util';
 import * as SlackInteractionHandler from './slack_interaction_handler';
 import { PromisifiedRedisClient } from './redis_client';
 import * as SlackBlockUtil from './slack_block_util';
 import { cloneDeep } from 'lodash';
+import { SlackActionId } from './slack_interaction_ids';
 
 export async function replaceSlackMessageBlocks({
   slackChannelId,
@@ -45,11 +46,13 @@ export function addBackVoterStatusPanel({
   slackChannelId,
   slackParentMessageTs,
   oldBlocks,
+  status,
   topics,
 }: {
   slackChannelId: string;
   slackParentMessageTs: string;
   oldBlocks: SlackBlock[];
+  status: VoterStatus;
   topics: string[];
 }): Promise<void> {
   logger.info('ENTERING SLACKINTERACTIONAPIUTIL.addBackVoterStatusPanel');
@@ -59,18 +62,28 @@ export function addBackVoterStatusPanel({
   const newBlocks = [voterInfoBlock, volunteerDropdownBlock];
   newBlocks.push(voterStatusPanel);
 
-  const topicBlock = cloneDeep(voterTopicPanel);
-  topicBlock.accessory.initial_options = topics.map((topic) => {
-    return {
-      text: {
-        type: 'plain_text',
-        text: SessionTopics[topic],
-      },
-      value: topic,
-    };
-  });
-  newBlocks.push(topicBlock);
+  if (status !== 'UNKNOWN') {
+    SlackBlockUtil.populateDropdownNewInitialValue(
+      newBlocks,
+      SlackActionId.VOTER_STATUS_DROPDOWN,
+      status
+    );
+  }
 
+  const topicBlock = cloneDeep(voterTopicPanel);
+  if (topics.length > 0) {
+    topicBlock.accessory.initial_options = topics.map((topic) => {
+      return {
+        text: {
+          type: 'plain_text',
+          text: SessionTopics[topic],
+        },
+        value: topic,
+      };
+    });
+  }
+  newBlocks.push(topicBlock);
+  logger.info(JSON.stringify(newBlocks));
   return replaceSlackMessageBlocks({
     slackChannelId,
     slackParentMessageTs,

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -293,10 +293,16 @@ export async function handleVoterStatusUpdate({
       twilioPhoneNumber,
     });
 
+    const topics =
+      (await DbApiUtil.getThreadTopics(
+        payload.channel.id,
+        payload.container.thread_ts
+      )) || [];
     await SlackInteractionApiUtil.addBackVoterStatusPanel({
       slackChannelId: payload.channel.id,
       slackParentMessageTs: payload.container.thread_ts,
       oldBlocks: payload.message.blocks,
+      topics: topics,
     });
 
     // For code simplicity, this executes even if "VOTED" is the button clicked before "UNDO".

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -292,16 +292,22 @@ export async function handleVoterStatusUpdate({
       userPhoneNumber,
       twilioPhoneNumber,
     });
-
+    const MD5 = new Hashes.MD5();
+    const userId = MD5.hex(userPhoneNumber);
     const topics =
       (await DbApiUtil.getThreadTopics(
         payload.channel.id,
         payload.container.thread_ts
       )) || [];
+    const status = ((await DbApiUtil.getLatestVoterStatus(
+      userId,
+      twilioPhoneNumber
+    )) || 'UNKNOWN') as VoterStatus;
     await SlackInteractionApiUtil.addBackVoterStatusPanel({
       slackChannelId: payload.channel.id,
       slackParentMessageTs: payload.container.thread_ts,
       oldBlocks: payload.message.blocks,
+      status: status,
       topics: topics,
     });
 

--- a/src/slack_interaction_ids.ts
+++ b/src/slack_interaction_ids.ts
@@ -29,6 +29,8 @@ export enum SlackActionId {
 
   VOTER_SESSION_EXPAND = 'VOTER_SESSION_EXPAND',
   VOTER_SESSION_HIDE = 'VOTER_SESSION_HIDE',
+
+  SESSION_TOPICS = 'SESSION_TOPICS',
 }
 
 // Prefixes per-state blocks in open-close channel modal

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,15 @@ export type Request = express.Request & { rawBody: string };
 export const SessionTopics = {
   VERIFY: 'How to verify voter registration',
   REGISTER: 'How to register to vote',
-  REQUEST_BALLOT: 'How to request an absentee ballot',
-  RETURN_BALLOT: 'How to return a ballot',
+  ABSENTEE_REQUEST: 'How to request an absentee ballot',
+  ABSENTEE_BALLOT_DID_NOT_ARRIVE: 'Absentee ballot did not arrive',
+  ABSENTEE_BALLOT_DAMAGED: 'Absentee ballot was damaged',
+  ABSENTEE_BALLOT_MULTIPLE: 'Multiple absentee ballots arrived',
+  ABSENTEE_BALLOT_RETURN: 'How to return a ballot',
+  ABSENTEE_BALLOT_TRACK: 'How to track my ballot',
   WHERE_TO_VOTE: 'Where to vote',
+  VOTE_EARLY: 'How to vote early',
+  ABSENTEE_VOTE_IN_PERSON:
+    'How to vote in person despite having absentee ballot',
+  UNUSUAL_QUESTION: 'Unusual and/or uncategorized question',
 } as Record<string, string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,3 +53,11 @@ export type SlackThreadInfo = {
 };
 
 export type Request = express.Request & { rawBody: string };
+
+export const SessionTopics = {
+  VERIFY: 'How to verify voter registration',
+  REGISTER: 'How to register to vote',
+  REQUEST_BALLOT: 'How to request an absentee ballot',
+  RETURN_BALLOT: 'How to return a ballot',
+  WHERE_TO_VOTE: 'Where to vote',
+} as Record<string, string>;


### PR DESCRIPTION
The idea here is to record which questions were asked or topics discussed during a helpline session.  This can be used for later data analysis.

We add a new table that is keyed off of the *session* (user_id, twilio_phone_number, session_start_at).  It includes a jsonb column that has a JSON array of topics.

The voter header in slack now contains a multi-select that lets you pick one or more (or no) topics.  This block is hidden if the voter is marked Refused or Spam, and restored on Undo.  The slack multi-selector isn't the greatest UX (you can't see what is selected unless you open it up; another click is needed before you see available options; two more clicks after making your pick to close the dialog), but it's what we have available.

If there are past session for the voter, the topics dicussed are include in the history message.

![image](https://user-images.githubusercontent.com/433031/99300826-b1a78400-2812-11eb-99b2-94add73b8d4b.png)
![image](https://user-images.githubusercontent.com/433031/99300852-bb30ec00-2812-11eb-92da-e03f7411de0a.png)
![image](https://user-images.githubusercontent.com/433031/99300913-d6036080-2812-11eb-8ff2-7b90ba201bd7.png)

Edge cases / QA tests:

- The # of selected items should update in both the thread and the channel
- If you do refused or spam and then undo, when the block reappears it should show the same selected items
- Routing a voter between channels should preserve the topics.  Same goes for a voter in the lobby who has topics selected and then texts their state and gets routed automatically
