### PR TITLE
Create Route to Journey message shortcut

### DIFF
--- a/external_config/slack.md
+++ b/external_config/slack.md
@@ -50,11 +50,10 @@ Important: The Slack bot must be given access to each of these channels.
 - north-carolina-0
 - demo-north-carolina-0
 
-You must also create these channels and note their channel IDs (use Copy Link and get the `Cxxxxxx` part).  Set the appropriate values in .env:
+You must also create these channels and note their channel IDs (use Copy Link and get the `Cxxxxxx` part). Set the appropriate values in .env:
 
-- admin-control-room  (ADMIN_CONTROL_ROOM_SLACK_CHANNEL_ID)
-- attachments  (ATTACHMENTS_SLACK_CHANNEL_ID)
-
+- admin-control-room (ADMIN_CONTROL_ROOM_SLACK_CHANNEL_ID)
+- attachments (ATTACHMENTS_SLACK_CHANNEL_ID)
 
 #### Redis
 
@@ -108,9 +107,9 @@ HMSET stateRegionConfig "Alabama" "Central" "Alaska" "Pacific" "Arizona" "Arizon
 
 #### OAuth Tokens & Redirect URLs
 
-Create an **OAuth Access Token** and put it in `.env` as `SLACK_USER_ACCESS_TOKEN`.  It should start with `xoxp-`.
+Create an **OAuth Access Token** and put it in `.env` as `SLACK_USER_ACCESS_TOKEN`. It should start with `xoxp-`.
 
-Create a **Bot User OAuth Access Token** and put it in `.env` as `SLACK_BOT_ACCESS_TOKEN`.  It should start with `xoxb-`.
+Create a **Bot User OAuth Access Token** and put it in `.env` as `SLACK_BOT_ACCESS_TOKEN`. It should start with `xoxb-`.
 
 #### Scopes
 
@@ -184,6 +183,12 @@ This should be added as a **global** shortcut.
 - **Name:** Manage Entry Points
 - **Short Description:** Manage entry points by state or region
 - **Callback ID:** manage_entry_points
+
+This should be added as a **messages** shortcut.
+
+- **Name:** Route to Journey
+- **Short Description:** Routes this voter to a new channel for follow-up
+- **Callback ID:** route_to_journey
 
 ### Slash commands
 

--- a/sql/20201117-route-to-journey-command.sql
+++ b/sql/20201117-route-to-journey-command.sql
@@ -1,0 +1,3 @@
+-- Add ROUTE_TO_JOURNEY type to table of commands volunteers can issue (only other existing one is RESET_DEMO)
+
+ALTER TYPE command_type ADD VALUE 'ROUTE_TO_JOURNEY';

--- a/src/app.ts
+++ b/src/app.ts
@@ -726,6 +726,7 @@ app.post(
         SlackCallbackId.RESET_DEMO,
         SlackCallbackId.MANAGE_ENTRY_POINTS,
         SlackCallbackId.SHOW_NEEDS_ATTENTION,
+        SlackCallbackId.ROUTE_TO_JOURNEY,
       ].includes(payload.callback_id as SlackCallbackId)
     ) {
       logger.info(

--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -502,10 +502,13 @@ async function slackInteractivityHandler(
       }
 
       case SlackCallbackId.ROUTE_TO_JOURNEY: {
-        const modalPrivateMetadata = JSON.parse(
+        const modalPrivateMetadata = SlackInteractionHandler.parseSlackModalPrivateMetadata(
           payload.view.private_metadata
-        ) as SlackModalPrivateMetadata;
-        if (modalPrivateMetadata.commandType !== 'ROUTE_TO_JOURNEY') {
+        );
+        if (
+          modalPrivateMetadata &&
+          modalPrivateMetadata.commandType !== 'ROUTE_TO_JOURNEY'
+        ) {
           throw new Error(
             `Got callback ID ROUTE_TO_JOURNEY but private commandType was ${modalPrivateMetadata.commandType}`
           );

--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -243,12 +243,58 @@ async function slackInteractivityHandler(
           );
           await SlackApiUtil.updateModal(viewId, slackView);
           logger.info(
-            `SLACKINTERACTIONHANDLER.receiveResetDemo: Volunteer used a shortcut on an invalid message.`
+            `ASYNCJOBS.slackInteractivityHandler: Volunteer used a reset demo shortcut on an invalid message.`
           );
           return;
         }
 
         await SlackInteractionHandler.receiveResetDemo({
+          payload,
+          redisClient,
+          modalPrivateMetadata,
+          twilioPhoneNumber: redisData.twilioPhoneNumber,
+          userId: MD5.hex(redisData.userPhoneNumber),
+          viewId,
+        });
+        return;
+      }
+
+      case SlackCallbackId.ROUTE_TO_JOURNEY: {
+        const { viewId } = interactivityMetadata;
+        if (!viewId) {
+          throw new Error(
+            'slackInteractivityHandler called for message_action without viewId'
+          );
+        }
+
+        const MD5 = new Hashes.MD5();
+
+        // Ignore Prettier formatting because this object needs to adhere to JSON strigify requirements.
+        // prettier-ignore
+        const modalPrivateMetadata = {
+          "commandType": 'ROUTE_TO_JOURNEY',
+          "userId": redisData ? MD5.hex(redisData.userPhoneNumber) : null,
+          "twilioPhoneNumber": redisData ? redisData.twilioPhoneNumber : null,
+          "originatingSlackUserName": originatingSlackUserName,
+          // destinationSlackChannelName is populated later
+        } as SlackModalPrivateMetadata;
+
+        if (!originatingSlackChannelName || !redisData) {
+          modalPrivateMetadata.success = false;
+          modalPrivateMetadata.failureReason = 'invalid_shortcut_use';
+          await DbApiUtil.logCommandToDb(modalPrivateMetadata);
+          const slackView = SlackBlockUtil.getErrorSlackView(
+            'not_active_voter_parent_thread',
+            'This shortcut is not valid on this message.'
+          );
+          await SlackApiUtil.updateModal(viewId, slackView);
+          logger.info(
+            `ASYNCJOBS.slackInteractivityHandler: Volunteer used a route to journey shortcut on an invalid message.`
+          );
+          return;
+        }
+
+        await SlackInteractionHandler.receiveRouteToJourney({
           payload,
           redisClient,
           modalPrivateMetadata,
@@ -449,6 +495,22 @@ async function slackInteractivityHandler(
           );
         }
         await SlackInteractionHandler.handleResetDemo(
+          redisClient,
+          modalPrivateMetadata
+        );
+        return;
+      }
+
+      case SlackCallbackId.ROUTE_TO_JOURNEY: {
+        const modalPrivateMetadata = JSON.parse(
+          payload.view.private_metadata
+        ) as SlackModalPrivateMetadata;
+        if (modalPrivateMetadata.commandType !== 'ROUTE_TO_JOURNEY') {
+          throw new Error(
+            `Got callback ID ROUTE_TO_JOURNEY but private commandType was ${modalPrivateMetadata.commandType}`
+          );
+        }
+        await SlackInteractionHandler.handleRouteToJourney(
           redisClient,
           modalPrivateMetadata
         );

--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -276,6 +276,9 @@ async function slackInteractivityHandler(
           "userId": redisData ? MD5.hex(redisData.userPhoneNumber) : null,
           "twilioPhoneNumber": redisData ? redisData.twilioPhoneNumber : null,
           "originatingSlackUserName": originatingSlackUserName,
+          "originatingSlackUserId": payload.user.id,
+          "slackChannelId": payload.channel.id,
+          "slackParentMessageTs": thread_ts,
           // destinationSlackChannelName is populated later
         } as SlackModalPrivateMetadata;
 

--- a/src/load_balancer.test.js
+++ b/src/load_balancer.test.js
@@ -1,0 +1,60 @@
+const LoadBalancer = require('./load_balancer');
+
+describe('convertSlackChannelNameToStateOrRegionName', () => {
+  test('Removes pod number and capitalizes U.S. state name.', () => {
+    expect(
+      LoadBalancer.convertSlackChannelNameToStateOrRegionName(`texas-0`)
+    ).toBe('Texas');
+  });
+
+  test('Removes pod number, capitalizes U.S. state name and adds space if two-word.', () => {
+    expect(
+      LoadBalancer.convertSlackChannelNameToStateOrRegionName(
+        `north-carolina-0`
+      )
+    ).toBe('North Carolina');
+  });
+
+  test('Removes pod number, capitalizes U.S. state name and adds space if three-word.', () => {
+    expect(
+      LoadBalancer.convertSlackChannelNameToStateOrRegionName(
+        `district-of-columbia-0`
+      )
+    ).toBe('District of Columbia');
+  });
+
+  test('Removes pod number, capitalizes region and adds space even if two-word.', () => {
+    expect(
+      LoadBalancer.convertSlackChannelNameToStateOrRegionName(`eastern-north-7`)
+    ).toBe('Eastern North');
+  });
+
+  test('Removes pod number, capitalizes region and adds space even if multi-word.', () => {
+    expect(
+      LoadBalancer.convertSlackChannelNameToStateOrRegionName(`in-nh-vt-7`)
+    ).toBe('In Nh Vt');
+  });
+
+  test('Handles large pod numbers.', () => {
+    expect(
+      LoadBalancer.convertSlackChannelNameToStateOrRegionName(`florida-100`)
+    ).toBe('Florida');
+  });
+
+  test('Handles demo channels.', () => {
+    expect(
+      LoadBalancer.convertSlackChannelNameToStateOrRegionName(
+        `demo-florida-100`
+      )
+    ).toBe('Florida');
+  });
+
+  test('Handles national channels.', () => {
+    expect(
+      LoadBalancer.convertSlackChannelNameToStateOrRegionName(`demo-national-0`)
+    ).toBe('National');
+    expect(
+      LoadBalancer.convertSlackChannelNameToStateOrRegionName(`national-0`)
+    ).toBe('National');
+  });
+});

--- a/src/pod_util.ts
+++ b/src/pod_util.ts
@@ -49,9 +49,6 @@ async function isValidStateOrRegionName(
 }
 
 export const getEntrypointTypes = (): EntryPoint[] => {
-  if (process.env.CLIENT_ORGANIZATION === 'VOTE_AMERICA') {
-    return ['PULL'];
-  }
   return ['PULL', 'PUSH'];
 };
 

--- a/src/redis_api_util.ts
+++ b/src/redis_api_util.ts
@@ -1,7 +1,7 @@
 import bluebird from 'bluebird';
 import { Multi } from 'redis';
 import logger from './logger';
-import type { PromisifiedRedisClient } from './redis_client';
+import { PromisifiedRedisClient } from './redis_client';
 
 const fieldTypes: {
   [fieldName: string]: 'string' | 'boolean' | 'integer' | undefined;

--- a/src/router.ts
+++ b/src/router.ts
@@ -786,7 +786,7 @@ export async function routeVoterToSlackChannel(
     destinationSlackChannelName: string;
   },
   adminCommandParams?: AdminCommandParams /* only for admin rerouteVoterToSlackChannel-routes or Route to Journey shortcut (not automated)*/
-) {
+): Promise<void> {
   const skipLobby =
     (await RedisApiUtil.getKey(redisClient, 'skipLobby')) === 'true';
 

--- a/src/slack_block_entrypoint_util.ts
+++ b/src/slack_block_entrypoint_util.ts
@@ -201,7 +201,7 @@ export async function getOpenCloseModal({
         type: 'header',
         text: {
           type: 'plain_text',
-          text: 'Pull',
+          text: 'Frontline',
         },
       });
       rows = rows.concat(pullBlocks);
@@ -211,7 +211,7 @@ export async function getOpenCloseModal({
         type: 'header',
         text: {
           type: 'plain_text',
-          text: 'Push',
+          text: 'Journey',
         },
       });
       rows = rows.concat(pushBlocks);

--- a/src/slack_block_util.ts
+++ b/src/slack_block_util.ts
@@ -318,9 +318,10 @@ export function loadingSlackView(): SlackView {
   };
 }
 
-export function resetConfirmationSlackView(
+export function confirmationSlackView(
   callbackId: string,
-  modalPrivateMetadata: SlackModalPrivateMetadata
+  modalPrivateMetadata: SlackModalPrivateMetadata,
+  modalMessage: string
 ): SlackView {
   return {
     callback_id: callbackId,
@@ -338,8 +339,7 @@ export function resetConfirmationSlackView(
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text:
-            'Are you sure you want to end your demo conversation with this volunteer?\n\nYou will no longer be able to send messages to or receive messages from them, and they will be treated as a new demo voter the next time they send a text to this phone number.',
+          text: modalMessage,
         },
       },
     ],

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -114,6 +114,23 @@ export type SlackModalPrivateMetadata = {
   failureReason?: string;
 };
 
+export function parseSlackModalPrivateMetadata(
+  modalPrivateMetadataString: string
+): SlackModalPrivateMetadata {
+  let modalPrivateMetadataObject;
+  try {
+    modalPrivateMetadataObject = JSON.parse(
+      modalPrivateMetadataString
+    ) as SlackModalPrivateMetadata;
+  } catch (e) {
+    logger.error(
+      'SLACKINTERACTIONHANDLER.parseSlackModalPrivateMetadata: Error parsing slackModalPrivateMetadata'
+    );
+    throw e;
+  }
+  return modalPrivateMetadataObject;
+}
+
 const getClosedVoterPanelText = (
   selectedVoterStatus: VoterStatusUpdate,
   originatingSlackUserName: string
@@ -1162,7 +1179,7 @@ export async function receiveResetDemo({
         'demo_reset_error_not_demo',
         'This shortcut is strictly for demo conversations only. Please reach out to an admin for assistance.'
       );
-    } else if (!(payload.channel.id === userInfo.activeChannelId)) {
+    } else if (payload.channel.id !== userInfo.activeChannelId) {
       modalPrivateMetadata.success = false;
       modalPrivateMetadata.failureReason = 'non_active_thread';
       await DbApiUtil.logCommandToDb(modalPrivateMetadata);

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -1279,9 +1279,7 @@ export async function receiveRouteToJourney({
             'route_to_journey_error_no_pods_found',
             `No journey pods found for U.S. state name: *${activeStateName}*. Please contact an admin.`
           );
-        } else if (
-          activeSlackChannelName === selectedSlackChannelName
-        ) {
+        } else if (activeSlackChannelName === selectedSlackChannelName) {
           slackView = SlackBlockUtil.getErrorSlackView(
             'route_to_journey_error_routing_to_same_channel',
             `The voter is already in an open journey pod for this U.S. state.`

--- a/src/slack_interaction_ids.ts
+++ b/src/slack_interaction_ids.ts
@@ -9,6 +9,7 @@ export enum SlackCallbackId {
   SHOW_NEEDS_ATTENTION = 'show_needs_attention',
   SET_NEEDS_ATTENTION = 'set_needs_attention',
   CLEAR_NEEDS_ATTENTION = 'clear_needs_attention',
+  ROUTE_TO_JOURNEY = 'route_to_journey',
 }
 
 // Action IDs are used in interactive blocks


### PR DESCRIPTION
Based on top of #214 Session topics

Technical notes:
- Since VoteAmerica is not using the PUSH functionality, Push will be used to indicate Journey. This will generate new sets of open pods that can be used to track and easily update which pods can receive additional voters for journey.
- I needed to change the LoadBalancer to accept regions as state names. Usually the load balancer only handles completely new voters, which are routed based on their state name. But because a voter might have been routed to a different state before being routed to journey, we need to parse their state name from the Slack channel name, and accommodate situations in which this is not a state but a region name.
- Push/Pull has a completely different purpose for other organizations, but because VoteAmerica doesn't use the push open channel lists at all, the lists can be conveniently repurposed for the concept of Journey instead. Note: All push paths in the router are still inactive, as there are no phone numbers associated with push in the original sense.
- The routeVoterToSlackFunction usually takes an adminCommandParams argument that includes information about the message of the admin command. This PR accepts a third way to route a voter, which includes the adminCommandParams but without the message details (since the routing mechanism is a message shortcut instead of a command).

This feature has two objectives:
- Leverage volunteers who are especially highly trained and knowledgeable about voting rules to focus on incoming voter questions, which are likely the most difficult questions and most important to helping the voter successfully vote. This role is **frontline** volunteer.
- Systematize follow-up with voters by having volunteers "adopt" and "shepherd" a group of voters (e.g. 20 each) until they successfully vote. This role is **journey** volunteer.

Each pod will be designated as a "frontline" or "journey" pod, with all volunteers in a pod having one of the two above responsibilities. Journey pods will be closed to the traditional entrypoint and thus not receive any new voters. Instead, frontline pods will receive new voters, and when a volunteer is done with a conversation, they should mention to the voter that they are connecting them with a volunteer who will be available to answer any additional questions that come up through Election Day.

This feature will be a message shortcut Route to Journey. In the normal use case, a volunteer will be able to select this shortcut on any message within a voter's thread. A modal will appear to confirm this is the action the volunteer wants to take. If confirmed, the subsequent operations will:
1. Determine which journey pods (Slack channels) are open for this state as well as the state of the counter that round robins voters to these pods. This helps determine which pod the voter should be routed to.
2. The remaining operations should be the equivalent of a manual admin action to route the voter to the selected pod.

Edge cases / QA tests:
- If a volunteer selects the shortcut on any message outside of a voter thread, a modal appears instructing them on proper usage.
- If a volunteer selects Route to Journey for a voter thread that is already listed as a journey pod for that same U.S. state, if the same pod is selected, an error modal appears rather than routing the voter to the same channel.
- If no journey pod is open, the volunteer receives a modal letting them know.
- If a voter is in a region channel, they should be routed to a journey pod that corresponds to that region.
- If a voter selects U.S. state A and then is routed to U.S. state B and is then routed to journey, they should be routed to a state B journey pod (not state A).
- Trying to Route to Journey a voter that is in a national pod should return a modal that says there are no open journey pods for this state.
- Make sure I didn't break any of the other message shortcuts (in particular Reset Demo).