### PR TITLE
Revert "react when we get a slack message on an archived thread"

### DIFF
--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -528,11 +528,6 @@ async function slackMessageEventHandler(
     logger.info(
       'SERVER POST /slack: Server received non-bot Slack message OUTSIDE a voter thread. Doing nothing.'
     );
-    await SlackApiUtil.addSlackMessageReaction(
-      reqBody.event.channel,
-      reqBody.event.ts,
-      'zombie'
-    );
   }
 }
 


### PR DESCRIPTION
This reverts commit 76422095e9fe26be01f4e3dfb653b95e3da9340c.

This triggers on any slack message in a channel including the bot that isn't part of a thread... which is confusing (though otherwise harmless) and not at all what was intended.