### PR TITLE
Handle JOIN to resubscribe, and HELPLINE while refused

### DIFF
--- a/sql/20201113-reset-voter-status.sql
+++ b/sql/20201113-reset-voter-status.sql
@@ -5,6 +5,7 @@ WITH latest_status AS (
         *
         , row_number () OVER (PARTITION BY user_id, twilio_phone_number ORDER BY created_at DESC) AS rn
     FROM voter_status_updates
+    WHERE voter_status NOT IN ('REFUSED', 'SPAM', 'REJOIN')
 )
 INSERT INTO voter_status_updates (created_at, user_id, user_phone_number, twilio_phone_number, is_demo, voter_status)
 SELECT now(), user_id, user_phone_number, twilio_phone_number, is_demo, 'REGISTERED'

--- a/sql/20201123-rejoin.sql
+++ b/sql/20201123-rejoin.sql
@@ -1,0 +1,2 @@
+-- Add REJOIN to enum values for voter_status
+ALTER TYPE voter_status ADD VALUE 'REJOIN';

--- a/src/app.ts
+++ b/src/app.ts
@@ -299,11 +299,18 @@ const handleIncomingTwilioMessage = async (
       logger.info(
         `SERVER.handleIncomingTwilioMessage: Received JOIN from refused phone number: ${userPhoneNumber}, unblocking.`
       );
-        // Start allowing texts to this voter
+      // Start allowing texts to this voter
       await RedisApiUtil.deleteHashField(
         redisClient,
         'slackBlockedUserPhoneNumbers',
         userPhoneNumber
+      );
+      const MD5 = new Hashes.MD5();
+      await DbApiUtil.logRejoinStatusToDb(
+        MD5.hex(userPhoneNumber),
+        userPhoneNumber,
+        twilioPhoneNumber,
+        LoadBalancer.phoneNumbersAreDemo(twilioPhoneNumber, userPhoneNumber)
       );
       if (userInfo) {
         // Treat this as a new session

--- a/src/app.ts
+++ b/src/app.ts
@@ -156,7 +156,7 @@ export async function handleKnownVoterBlockLogic(
     userPhoneNumber
   );
 
-  if (userMessage.toLowerCase().trim() === 'stop') {
+  if (KeywordParser.isStopKeyword(userMessage)) {
     logger.info(
       `SERVER.handleIncomingTwilioMessage: Received STOP text from phone number: ${userPhoneNumber}.`
     );

--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -1418,6 +1418,7 @@ const LAST_VOTER_STATUS_SQL_SCRIPT = `SELECT voter_status
                                         WHERE user_id = $1
                                           AND twilio_phone_number = $2
                                           AND archived IS NOT TRUE
+                                          AND voter_status NOT IN ('REFUSED', 'SPAM', 'REJOIN')
                                         ORDER BY created_at DESC
                                         LIMIT 1;`;
 

--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -1302,6 +1302,7 @@ export async function getThreadsNeedingFollowUp(
           AND c.volunteer_slack_user_id = $1
           AND s.user_id = t.user_id
           AND s.is_demo = t.is_demo
+          AND s.voter_status NOT IN ('REFUSED', 'SPAM')
         ORDER BY updated_at`,
       [slackUserId]
     );

--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -1393,6 +1393,25 @@ export async function logInitialVoterStatusToDb(
   }
 }
 
+export async function logRejoinStatusToDb(
+  userId: string,
+  userPhoneNumber: string,
+  twilioPhoneNumber: string,
+  isDemo: boolean
+): Promise<void> {
+  logger.info(`ENTERING DBAPIUTIL.logRejoinStatusToDb`);
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `INSERT INTO voter_status_updates (user_id, user_phone_number, twilio_phone_number, voter_status, is_demo)
+      VALUES ($1, $2, $3, 'REJOIN', $4)`,
+      [userId, userPhoneNumber, twilioPhoneNumber, isDemo]
+    );
+  } finally {
+    client.release();
+  }
+}
+
 const LAST_VOTER_STATUS_SQL_SCRIPT = `SELECT voter_status
                                         FROM voter_status_updates
                                         WHERE user_id = $1

--- a/src/keyword_parser.ts
+++ b/src/keyword_parser.ts
@@ -9,6 +9,10 @@ export function isStopKeyword(userMessage: string): boolean {
   return userMessage.toLowerCase().trim() === 'stop';
 }
 
+export function isJoinKeyword(userMessage: string): boolean {
+  return userMessage.toLowerCase().trim() === 'join';
+}
+
 export function isVotedKeyword(userMessage: string): boolean {
   return [
     'voted',

--- a/src/message_constants.ts
+++ b/src/message_constants.ts
@@ -87,6 +87,10 @@ export function VOTED_RESPONSE(): string {
   return 'Thank you for voting!';
 }
 
+export function HELPLINE_AFTER_STOP_RESPONSE(): string {
+  return 'You have previously opted out of VoteAmerica text messages. To access the voter helpline, first text JOIN to resubscribe to VoteAmerica election alerts, and then text HELPLINE again to reach a volunteer. Msg&data rates apply.';
+}
+
 export function STATE_QUESTION(): string {
   switch (process.env.CLIENT_ORGANIZATION) {
     case 'VOTE_AMERICA':

--- a/src/slack_interaction_api_util.ts
+++ b/src/slack_interaction_api_util.ts
@@ -61,14 +61,11 @@ export function addBackVoterStatusPanel({
   const volunteerDropdownBlock = oldBlocks[1];
   const newBlocks = [voterInfoBlock, volunteerDropdownBlock];
   newBlocks.push(voterStatusPanel);
-
-  if (status !== 'UNKNOWN') {
-    SlackBlockUtil.populateDropdownNewInitialValue(
-      newBlocks,
-      SlackActionId.VOTER_STATUS_DROPDOWN,
-      status
-    );
-  }
+  SlackBlockUtil.populateDropdownNewInitialValue(
+    newBlocks,
+    SlackActionId.VOTER_STATUS_DROPDOWN,
+    status
+  );
 
   const topicBlock = cloneDeep(voterTopicPanel);
   if (topics.length > 0) {
@@ -83,7 +80,7 @@ export function addBackVoterStatusPanel({
     });
   }
   newBlocks.push(topicBlock);
-  logger.info(JSON.stringify(newBlocks));
+
   return replaceSlackMessageBlocks({
     slackChannelId,
     slackParentMessageTs,

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -303,16 +303,20 @@ export async function handleVoterStatusUpdate({
     logger.info(
       `SLACKINTERACTIONHANDLER.handleVoterStatusUpdate: Determined user interaction is UNDO of voter status update`
     );
+    const MD5 = new Hashes.MD5();
+    const userId = MD5.hex(userPhoneNumber);
+    const previousStatus = ((await DbApiUtil.getLatestVoterStatus(
+      userId,
+      twilioPhoneNumber
+    )) || 'UNKNOWN') as VoterStatusUpdate;
     await handleVoterStatusUpdateHelper({
       payload,
-      selectedVoterStatus: 'UNKNOWN',
+      selectedVoterStatus: previousStatus,
       originatingSlackUserName,
       slackChannelName,
       userPhoneNumber,
       twilioPhoneNumber,
     });
-    const MD5 = new Hashes.MD5();
-    const userId = MD5.hex(userPhoneNumber);
     const topics =
       (await DbApiUtil.getThreadTopics(
         payload.channel.id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type VoterStatus =
   | 'IN_PERSON'
   | 'VOTED'
   | 'REFUSED'
+  | 'REJOIN'
   | 'SPAM';
 
 type UserInfoCore = {


### PR DESCRIPTION
- Texting JOIN will resubscribe a user to the VoteAmerica list, and should reverse a previous STOP.  After JOIN the user
will be able to reenter the helpline (by texting HELPLINE) via a fresh session.
- If the user has opted out and texts HELPLINE (e.g., because they saw a print ad), respond with a helpful message instructing them to send JOIN to resubscribe and then text HELPLINE again.