### PR TITLE
!state command and minor voter panel improvements

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -54,18 +54,15 @@ function voterHeader(
   announce: boolean,
   notice?: string
 ): string {
-  let r = '';
-  if (announce) {
-    if (userInfo.returningVoter) {
-      r = `<!channel> Returning *${userInfo.stateName}* voter`;
-    } else {
-      r = `<!channel> New *${userInfo.stateName}* voter`;
-    }
-    if (notice) {
-      r += ` (${notice})`;
-    }
-    r += '\n';
+  let r = announce ? '<!channel> ' : '';
+  // NOTE: we have to be careful here because returningVoter may be a boolean or string
+  r += `${String(userInfo.returningVoter) == 'true' ? 'Returning' : 'New'} ${
+    userInfo.stateName ? '*' + userInfo.stateName + '* ' : ''
+  }voter`;
+  if (notice) {
+    r += ` (${notice})`;
   }
+  r += '\n';
   r += `${userInfo.userId} via ${userInfo.twilioPhoneNumber}`;
   return r;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ type UserInfoCore = {
   numStateSelectionAttempts: number;
   sessionStartEpoch?: number;
   returningVoter?: boolean;
+  panelMessage?: string;
 };
 
 type UserInfoChannels = {


### PR DESCRIPTION
- ``!state <statename>`` can be used where we previously would route manually to a specific pod.  It chooses the pod for you (based on the balancing params), can take a state abbreviation, and also updates the UserInfo.stateName field.
- The panel intro string is cleaned up a bit with some minor inconsistencies fixed.