### PR TITLE
Remove the modal version of Needs Attention

### DIFF
--- a/external_config/slack.md
+++ b/external_config/slack.md
@@ -168,14 +168,6 @@ This should be added as a **messages** shortcut.
 - **Short Description**: Remove this thread from your Needs Attention list
 - **Callback ID**: clear_needs_attention
 
-##### Needs Attention
-
-This should be added as a **global** shortcut.
-
-- **Name:** Needs Attention
-- **Short Description:** Show voters needing attention
-- **Callback ID:** show_needs_attention
-
 ##### Manage Entry Points
 
 This should be added as a **global** shortcut.

--- a/src/async_jobs.ts
+++ b/src/async_jobs.ts
@@ -129,14 +129,6 @@ async function slackInteractivityHandler(
     }
 
     switch (payload.callback_id) {
-      case SlackCallbackId.SHOW_NEEDS_ATTENTION: {
-        await SlackInteractionHandler.handleShortcutShowNeedsAttention({
-          payload,
-          viewId,
-        });
-        return;
-      }
-
       case SlackCallbackId.MANAGE_ENTRY_POINTS: {
         logger.info(
           `SERVER POST /slack-interactivity: Determined user interaction is a MANAGE_ENTRY_POINTS_MODAL submission.`

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -1005,33 +1005,6 @@ export async function handleCommandFollowUp(
   await SlackApiUtil.sendEphemeralResponse(responseUrl, lines.join('\n'));
 }
 
-export async function handleShortcutShowNeedsAttention({
-  payload,
-  viewId,
-}: {
-  payload: SlackInteractionEventPayload;
-  viewId: string;
-}): Promise<void> {
-  const lines = await getNeedsAttentionList(payload.user.id);
-  const slackView: SlackBlockUtil.SlackView = {
-    title: {
-      type: 'plain_text',
-      text: `${lines.length} voters need attention`,
-    },
-    blocks: [
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: lines.join('\n') || 'No voters need attention right now',
-        },
-      },
-    ],
-    type: 'modal',
-  };
-  await SlackApiUtil.updateModal(viewId, slackView);
-}
-
 export async function handleSessionShow(
   payload: SlackInteractionEventPayload
 ): Promise<void> {


### PR DESCRIPTION
The recent slack UI change makes both of them pop up when you start
typing '/nee', which is confusing.  And the in-channel one is consistent
with all of the other commands and generally more useful.