### PR TITLE
Allow keywords that route directly to states

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -419,7 +419,10 @@ const handleIncomingTwilioMessage = async (
         const userMessageNoPunctuation = userMessage
           .toLowerCase()
           .replace(/[^a-zA-Z]/g, '');
-        if (userMessageNoPunctuation.startsWith('helpline')) {
+        if (
+          userMessageNoPunctuation.startsWith('helpline') ||
+          (await Router.parseStateKeyword(redisClient, userInfo, userMessage))
+        ) {
           await Router.handleNewVoter(
             userInfo,
             { userPhoneNumber, userMessage, userAttachments, userId },
@@ -583,7 +586,10 @@ const handleIncomingTwilioMessage = async (
     });
 
     if (process.env.CLIENT_ORGANIZATION === 'VOTE_AMERICA') {
-      if (KeywordParser.isHelplineKeyword(userMessage)) {
+      if (
+        KeywordParser.isHelplineKeyword(userMessage) ||
+        (await Router.parseStateKeyword(redisClient, userInfo, userMessage))
+      ) {
         await Router.handleNewVoter(
           userInfo,
           userOptions,

--- a/src/app.ts
+++ b/src/app.ts
@@ -421,7 +421,7 @@ const handleIncomingTwilioMessage = async (
           .replace(/[^a-zA-Z]/g, '');
         if (
           userMessageNoPunctuation.startsWith('helpline') ||
-          (await Router.parseStateKeyword(redisClient, userInfo, userMessage))
+          Router.parseStateKeyword(redisClient, userInfo, userMessage)
         ) {
           await Router.handleNewVoter(
             userInfo,
@@ -588,7 +588,7 @@ const handleIncomingTwilioMessage = async (
     if (process.env.CLIENT_ORGANIZATION === 'VOTE_AMERICA') {
       if (
         KeywordParser.isHelplineKeyword(userMessage) ||
-        (await Router.parseStateKeyword(redisClient, userInfo, userMessage))
+        Router.parseStateKeyword(redisClient, userInfo, userMessage)
       ) {
         await Router.handleNewVoter(
           userInfo,

--- a/src/router.ts
+++ b/src/router.ts
@@ -443,6 +443,27 @@ async function introduceNewVoterToSlackChannel(
   return response.data.ts;
 }
 
+export async function parseStateKeyword(
+  redisClient: PromisifiedRedisClient,
+  userInfo: UserInfo,
+  userMessage: string
+): Promise<boolean> {
+  // Is this a special keyword?
+  const keywords = await RedisApiUtil.getHash(redisClient, 'keywordConfig');
+  if (keywords) {
+    const keyword = userMessage.toLowerCase().replace(/[^a-zA-Z]/g, '');
+    const stateName = keywords[keyword];
+    if (stateName) {
+      logger.info(
+        `ROUTER.isStateKeyword recognized state keyword '${keyword}' -> ${stateName}`
+      );
+      userInfo.stateName = stateName;
+      return true;
+    }
+  }
+  return false;
+}
+
 export async function handleNewVoter(
   userInfo: UserInfo,
   userOptions: UserOptions & { userId: string },
@@ -477,29 +498,33 @@ export async function handleNewVoter(
         // Success: we know the state
         userInfo.stateName = stateName;
         userInfo.panelmessage = 'known phone number';
-        slackChannelName = await LoadBalancer.selectSlackChannel(
-          redisClient,
-          LoadBalancer.PULL_ENTRY_POINT,
-          stateName,
-          userInfo.isDemo
-        );
-        if (slackChannelName) {
-          // We can route them too
-          logger.info(
-            `ROUTER.handleNewVoter (${userInfo.userId}): New voter is in known state {stateName}, selected Slack channel {slackChannelName}`
-          );
-        } else {
-          // That state doesn't route for some reason; go to national
-          slackChannelName = userInfo.isDemo ? 'demo-national' : 'national';
-          logger.info(
-            `ROUTER.handleNewVoter (${userInfo.userId}): New voter is in known state {stateName}, but no channel match`
-          );
-        }
       } else {
         logger.warning(
           `ROUTER.handleNewVoter (${userInfo.userId}): unable to parse known state '${knownState}`
         );
       }
+    }
+  }
+
+  // userInfo.stateName may be populated above, or by parseStateKeyword
+  if (userInfo.stateName) {
+    slackChannelName = await LoadBalancer.selectSlackChannel(
+      redisClient,
+      LoadBalancer.PULL_ENTRY_POINT,
+      userInfo.stateName,
+      userInfo.isDemo
+    );
+    if (slackChannelName) {
+      // We can route them too
+      logger.info(
+        `ROUTER.handleNewVoter (${userInfo.userId}): New voter is in known state {stateName}, selected Slack channel {slackChannelName}`
+      );
+    } else {
+      // That state doesn't route for some reason; go to national
+      slackChannelName = userInfo.isDemo ? 'demo-national' : 'national';
+      logger.info(
+        `ROUTER.handleNewVoter (${userInfo.userId}): New voter is in known state {stateName}, but no channel match`
+      );
     }
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -443,21 +443,18 @@ async function introduceNewVoterToSlackChannel(
   return response.data.ts;
 }
 
-export async function parseStateKeyword(
+export function parseStateKeyword(
   redisClient: PromisifiedRedisClient,
   userInfo: UserInfo,
   userMessage: string
-): Promise<boolean> {
-  // Is this a special keyword?
-  const keywords = await RedisApiUtil.getHash(redisClient, 'keywordConfig');
-  if (keywords) {
+): boolean {
+  if (process.env.CLIENT_ORGANIZATION === 'VOTE_AMERICA') {
     const keyword = userMessage.toLowerCase().replace(/[^a-zA-Z]/g, '');
-    const stateName = keywords[keyword];
-    if (stateName) {
+    if (keyword === 'georgia') {
+      userInfo.stateName = 'Georgia';
       logger.info(
-        `ROUTER.isStateKeyword recognized state keyword '${keyword}' -> ${stateName}`
+        `ROUTER.isStateKeyword recognized state keyword '${keyword}' -> ${userInfo.stateName}`
       );
-      userInfo.stateName = stateName;
       return true;
     }
   }


### PR DESCRIPTION
This lets you set keywords in redis to route directly to a state.  it
does not allow for any customized messages to go with that, however.