### PR TITLE
Fix /unclaimed behavior

### DIFF
--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -1071,6 +1071,7 @@ export async function getThreadsNeedingAttentionByVolunteer(): Promise<
           AND t.user_id=c.user_id
           AND t.is_demo=c.is_demo
           AND c.rn=1
+          AND c.volunteer_slack_user_id IS NOT NULL
         GROUP BY volunteer_slack_user_id, volunteer_slack_user_name
         ORDER BY max_last_update_age DESC`
     );
@@ -1125,6 +1126,7 @@ export async function getThreadsNeedingAttentionForChannel(
           AND t.user_id=c.user_id
           AND t.is_demo=c.is_demo
           AND c.rn=1
+          AND c.volunteer_slack_user_id IS NOT NULL
           AND slack_channel_id = $1
         ORDER BY updated_at`,
       [channelId]


### PR DESCRIPTION
Fix /unclaimed behavior to properly handle voters who have been claimed and then released.  This can happen both when someone clicks the 'Clear volunteer' button or 'Routed to Journey'.

At the same time, fix a subtle behavior inconsistency with the /needs-attention results for the same claimed-then-released voters.