### PR TITLE
Tweaks to journey/frontline copy; create new thread for GA Dems returning voters

### DIFF
--- a/src/slack_block_entrypoint_util.ts
+++ b/src/slack_block_entrypoint_util.ts
@@ -262,7 +262,7 @@ export function openCloseConfirmationView({
       text: {
         type: 'mrkdwn',
         text:
-          ':warning: There are no *pull* entrypoints associated with this state or region.',
+          ':warning: There are no *frontline* pods associated with this state or region.',
       },
     });
   }
@@ -272,7 +272,7 @@ export function openCloseConfirmationView({
       text: {
         type: 'mrkdwn',
         text:
-          ':warning: There are no *push* entrypoints associated with this state or region.',
+          ':warning: There are no *journey* pods associated with this state or region.',
       },
     });
   }

--- a/src/slack_interaction_handler.ts
+++ b/src/slack_interaction_handler.ts
@@ -1455,7 +1455,9 @@ export async function handleManageEntryPoints({
     const channelString = channelInfo
       .map(
         ({ channelName, weight, entrypoint }) =>
-          `• ${entrypoint} \`${channelName}\` - *${weight}*`
+          `• ${
+            entrypoint === 'PULL' ? 'FRONTLINE' : 'JOURNEY'
+          } \`${channelName}\` - *${weight}*`
       )
       .sort()
       .join('\n');


### PR DESCRIPTION
- Consistently use the journey/frontline terminology rather than push/pull when changing entrypoints
- GA Dems wants a new thread when a voter returns after >24 hours. This modifies the "welcome back" behavior for GA dems to create a new thread by "routing" back to the same channel.