### PR TITLE
Tweaks to needs-attention and voter panel for GADEMS

### DIFF
--- a/src/db_api_util.ts
+++ b/src/db_api_util.ts
@@ -1126,10 +1126,11 @@ export async function getThreadsNeedingAttentionForChannel(
           AND t.user_id=c.user_id
           AND t.is_demo=c.is_demo
           AND c.rn=1
-          AND c.volunteer_slack_user_id IS NOT NULL
+          AND (c.volunteer_slack_user_id IS NOT NULL OR $2)
           AND slack_channel_id = $1
         ORDER BY updated_at`,
-      [channelId]
+      // GADEMS includes unassigned voters
+      [channelId, process.env.CLIENT_ORGANIZATION === 'GADEMS' ? true : false]
     );
     return result.rows.map((x) => ({
       slackParentMessageTs: x['slack_parent_message_ts'],

--- a/src/message_constants.ts
+++ b/src/message_constants.ts
@@ -87,7 +87,7 @@ export function WELCOME_AND_STATE_QUESTION(): string {
 export function WELCOME_FINDING_VOLUNTEER(state: string): string {
   switch (process.env.CLIENT_ORGANIZATION) {
     case 'GADEMS':
-      return `Hi! You’ve reached the Georgia Voter Assistance Helpline.\n\nWe are finding a volunteer and will be with you shortly. In the meantime, please share your name and question or concern.`;
+      return `Hi! You’ve reached the Georgia Voter Assistance Helpline.\n\nWe are finding a volunteer and will be with you shortly. In the meantime, please share more about how we can help.\n\nIf you are comfortable using our voice hotline, please call 888-730-5816.`;
     case 'VOTE_AMERICA':
       return `Welcome to the VoteAmerica Helpline! Msg&data rates may apply. Reply STOP to unsubscribe.\n\nWe are finding a volunteer for ${state}. Please share more about how we can help, or let us know if you are looking to vote in a different state.`;
     default:
@@ -98,7 +98,7 @@ export function WELCOME_FINDING_VOLUNTEER(state: string): string {
 export function FINDING_VOLUNTEER_IN_STATE(state: string): string {
   switch (process.env.CLIENT_ORGANIZATION) {
     case 'GADEMS':
-      return `We are finding a volunteer and will be with you shortly. In the meantime, please share your name and question or concern.`;
+      return `We are finding a volunteer and will be with you shortly. In the meantime, please share more about how we can help.\n\nIf you are comfortable using our voice hotline, please call 888-730-5816.`;
     default:
       return `We are finding a volunteer for ${state} and will be with you shortly. Please share more about how we can help, or let us know if you are looking to vote in a different state.`;
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -346,7 +346,8 @@ async function introduceNewVoterToSlackChannel(
   // PUSH/some clients: Write user reply to database and then pass message history to Slack.
   if (
     entryPoint === LoadBalancer.PUSH_ENTRY_POINT ||
-    process.env.CLIENT_ORGANIZATION === 'VOTE_AMERICA'
+    process.env.CLIENT_ORGANIZATION === 'VOTE_AMERICA' ||
+    process.env.CLIENT_ORGANIZATION === 'GADEMS'
   ) {
     logger.debug(
       `ROUTER.introduceNewVoterToSlackChannel: Retrieving and passing message history to Slack, slackChannelName: ${slackChannelName}, parentMessageTs: ${response.data.channel}.`

--- a/src/slack_block_util.ts
+++ b/src/slack_block_util.ts
@@ -134,84 +134,88 @@ const volunteerSelectionPanel: SlackBlock = {
 export const voterStatusPanel: SlackBlock = {
   type: 'actions',
   elements: [
-    {
-      type: 'static_select',
-      action_id: SlackActionId.VOTER_STATUS_DROPDOWN,
-      initial_option: {
-        text: {
-          type: 'plain_text',
-          text: 'Unknown',
-          emoji: true,
-        },
-        value: 'UNKNOWN',
-      },
-      options: [
-        {
-          text: {
-            type: 'plain_text',
-            text: 'Unknown',
-            emoji: true,
+    ...(process.env.CLIENT_ORGANIZATION === 'GADEMS'
+      ? []
+      : [
+          {
+            type: 'static_select',
+            action_id: SlackActionId.VOTER_STATUS_DROPDOWN,
+            initial_option: {
+              text: {
+                type: 'plain_text',
+                text: 'Unknown',
+                emoji: true,
+              },
+              value: 'UNKNOWN',
+            },
+            options: [
+              {
+                text: {
+                  type: 'plain_text',
+                  text: 'Unknown',
+                  emoji: true,
+                },
+                value: 'UNKNOWN',
+              },
+              {
+                text: {
+                  type: 'plain_text',
+                  text: 'Unregistered',
+                  emoji: true,
+                },
+                value: 'UNREGISTERED',
+              },
+              {
+                text: {
+                  type: 'plain_text',
+                  text: 'Registered',
+                  emoji: true,
+                },
+                value: 'REGISTERED',
+              },
+              {
+                text: {
+                  type: 'plain_text',
+                  text: 'Requested ballot',
+                  emoji: true,
+                },
+                value: 'REQUESTED_BALLOT',
+              },
+              {
+                text: {
+                  type: 'plain_text',
+                  text: 'Received ballot',
+                  emoji: true,
+                },
+                value: 'RECEIVED_BALLOT',
+              },
+              {
+                text: {
+                  type: 'plain_text',
+                  text: 'Will vote in-person',
+                  emoji: true,
+                },
+                value: 'IN_PERSON',
+              },
+              {
+                text: {
+                  type: 'plain_text',
+                  text: 'Voted :tada:',
+                  emoji: true,
+                },
+                value: 'VOTED',
+              },
+              {
+                text: {
+                  type: 'plain_text',
+                  text: 'Not voting this election :cry:',
+                  emoji: true,
+                },
+                value: 'NOT_VOTING',
+              },
+            ],
           },
-          value: 'UNKNOWN',
-        },
-        {
-          text: {
-            type: 'plain_text',
-            text: 'Unregistered',
-            emoji: true,
-          },
-          value: 'UNREGISTERED',
-        },
-        {
-          text: {
-            type: 'plain_text',
-            text: 'Registered',
-            emoji: true,
-          },
-          value: 'REGISTERED',
-        },
-        {
-          text: {
-            type: 'plain_text',
-            text: 'Requested ballot',
-            emoji: true,
-          },
-          value: 'REQUESTED_BALLOT',
-        },
-        {
-          text: {
-            type: 'plain_text',
-            text: 'Received ballot',
-            emoji: true,
-          },
-          value: 'RECEIVED_BALLOT',
-        },
-        {
-          text: {
-            type: 'plain_text',
-            text: 'Will vote in-person',
-            emoji: true,
-          },
-          value: 'IN_PERSON',
-        },
-        {
-          text: {
-            type: 'plain_text',
-            text: 'Voted :tada:',
-            emoji: true,
-          },
-          value: 'VOTED',
-        },
-        {
-          text: {
-            type: 'plain_text',
-            text: 'Not voting this election :cry:',
-            emoji: true,
-          },
-          value: 'NOT_VOTING',
-        },
-      ],
-    },
+        ]),
     {
       type: 'button',
       style: 'danger',
@@ -272,34 +276,38 @@ export const voterStatusPanel: SlackBlock = {
         },
       },
     },
-    {
-      type: 'button',
-      text: {
-        type: 'plain_text',
-        text: 'Route to Journey',
-        emoji: true,
-      },
-      action_id: SlackActionId.ROUTE_TO_JOURNEY,
-      confirm: {
-        title: {
-          type: 'plain_text',
-          text: 'Are you sure?',
-        },
-        text: {
-          type: 'mrkdwn',
-          text:
-            'Are you sure you want to route this voter to a journey pod?\n\nPlease remember to let the voter know that someone will be following up with them.',
-        },
-        confirm: {
-          type: 'plain_text',
-          text: 'Confirm',
-        },
-        deny: {
-          type: 'plain_text',
-          text: 'Cancel',
-        },
-      },
-    },
+    ...(process.env.CLIENT_ORGANIZATION === 'GADEMS'
+      ? []
+      : [
+          {
+            type: 'button',
+            text: {
+              type: 'plain_text',
+              text: 'Route to Journey',
+              emoji: true,
+            },
+            action_id: SlackActionId.ROUTE_TO_JOURNEY,
+            confirm: {
+              title: {
+                type: 'plain_text',
+                text: 'Are you sure?',
+              },
+              text: {
+                type: 'mrkdwn',
+                text:
+                  'Are you sure you want to route this voter to a journey pod?\n\nPlease remember to let the voter know that someone will be following up with them.',
+              },
+              confirm: {
+                type: 'plain_text',
+                text: 'Confirm',
+              },
+              deny: {
+                type: 'plain_text',
+                text: 'Cancel',
+              },
+            },
+          },
+        ]),
   ],
 };
 
@@ -409,7 +417,11 @@ function voterPanelHeader(userInfo: UserInfo): string {
     r += ` (${userInfo.panelMessage})`;
   }
   r += '\n';
-  r += `${userInfo.userId} via ${userInfo.twilioPhoneNumber}`;
+  if (process.env.CLIENT_ORGANIZATION === 'GADEMS') {
+    r += `${userInfo.userId} (${userInfo.userPhoneNumber})`;
+  } else {
+    r += `${userInfo.userId} via ${userInfo.twilioPhoneNumber}`;
+  }
   return r;
 }
 
@@ -427,7 +439,9 @@ export async function getVoterPanel(
     voterInfoSection(messageText),
     cloneDeep(volunteerSelectionPanel),
     cloneDeep(voterStatusPanel),
-    cloneDeep(voterTopicPanel),
+    ...(process.env.CLIENT_ORGANIZATION === 'GADEMS'
+      ? []
+      : [cloneDeep(voterTopicPanel)]),
   ];
 
   if (!volunteer) {
@@ -504,11 +518,13 @@ export async function getVoterPanel(
         },
       };
     } else {
-      populateDropdownNewInitialValue(
-        panel,
-        SlackActionId.VOTER_STATUS_DROPDOWN,
-        status
-      );
+      if (process.env.CLIENT_ORGANIZATION !== 'GADEMS') {
+        populateDropdownNewInitialValue(
+          panel,
+          SlackActionId.VOTER_STATUS_DROPDOWN,
+          status
+        );
+      }
     }
   }
 


### PR DESCRIPTION
I'm starting a new branch for GA Dems. They have a number of relatively small requests to make the system work better as a shift-based setup, where volunteers take shifts and don't have a longer-term relationship with voters. I've done our normal system of restricting these changes based on CLIENT_ORGANIZATION, but because they're relatively far-reaching and won't be needed in a week, it might be better not to merge this.